### PR TITLE
Add off-canvas hamburger nav, shorten app instructions, bump small te…

### DIFF
--- a/about.html
+++ b/about.html
@@ -20,13 +20,22 @@
 
 <body>
     <header>
-        <h1>About</h1>
-        <a class="backToMain" href="index.html">Home</a>
-        <ul>
-            <li><a href="app.html">Launch App</a></li>
-            <li><a href="articles.html">Articles</a></li>
-            <li><a href="contact.html">Contact</a></li>
-        </ul>
+        <div class="headerBar">
+            <h1>About</h1>
+            <button class="hamburgerBtn" id="hamburgerBtn" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer">
+                <span></span><span></span><span></span>
+            </button>
+        </div>
+        <nav class="navDrawer" id="navDrawer" aria-hidden="true">
+            <button class="navDrawerClose" id="navDrawerClose" aria-label="Close menu">&times;</button>
+            <a class="backToMain" href="index.html">Home</a>
+            <ul>
+                <li><a href="app.html">Launch App</a></li>
+                <li><a href="articles.html">Articles</a></li>
+                <li><a href="contact.html">Contact</a></li>
+            </ul>
+        </nav>
+        <div class="navOverlay" id="navOverlay"></div>
     </header>
 
     <div class="articleLayout">
@@ -103,6 +112,7 @@
         <p>Built by a dietitian, for dietitians (and the curious).</p>
     </footer>
 
+    <script src="nav.js"></script>
 </body>
 
 </html>

--- a/app.html
+++ b/app.html
@@ -37,13 +37,22 @@
 
 <body>
     <header>
-        <h1>Food intolerance guide</h1>
-        <a class="backToMain" href="index.html">Home</a>
-        <ul>
-            <li><a href="articles.html">Articles</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="contact.html">Contact</a></li>
-        </ul>
+        <div class="headerBar">
+            <h1>Food intolerance guide</h1>
+            <button class="hamburgerBtn" id="hamburgerBtn" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer">
+                <span></span><span></span><span></span>
+            </button>
+        </div>
+        <nav class="navDrawer" id="navDrawer" aria-hidden="true">
+            <button class="navDrawerClose" id="navDrawerClose" aria-label="Close menu">&times;</button>
+            <a class="backToMain" href="index.html">Home</a>
+            <ul>
+                <li><a href="articles.html">Articles</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="contact.html">Contact</a></li>
+            </ul>
+        </nav>
+        <div class="navOverlay" id="navOverlay"></div>
     </header>
 
     <div class="disclaimerBar">
@@ -69,10 +78,23 @@
             </div>
         </div>
 
-        <h2>A faster way to navigate food intolerances.</h2>
-        <p>1. Get started by choosing foods suspected of causing a negative reaction.</p>
-        <p>2. Further down you get a summary of what common factors the foods share.</p>
-        <p>3. In the end you'll get an analysis of what could be causing the negative reactions to the foods.</p>
+        <div class="instructionsBox">
+            <h2>A faster way to navigate food intolerances.</h2>
+            <ol class="stepsList">
+                <li>
+                    <span class="stepTitle">Pick the foods that bother you.</span>
+                    <span class="stepDetail">Choose any you suspect cause a reaction — change your mind anytime.</span>
+                </li>
+                <li>
+                    <span class="stepTitle">Check what they share.</span>
+                    <span class="stepDetail">A live summary below highlights shared FODMAPs, allergens, and more.</span>
+                </li>
+                <li>
+                    <span class="stepTitle">Read the full analysis.</span>
+                    <span class="stepDetail">Open the popup for a deeper breakdown of likely culprits.</span>
+                </li>
+            </ol>
+        </div>
         <div id="chosenFoods">
             <h2>Chosen items:</h2>
             <p id="chosenText">Click on a category to show lists of foods</p>
@@ -138,6 +160,7 @@
 
 <script src="foods-data.js"></script>
 <script src="articles-data.js"></script>
+<script src="nav.js"></script>
 <script src="script.js"></script>
 
 </html>

--- a/articles.html
+++ b/articles.html
@@ -27,13 +27,22 @@
 
 <body>
     <header>
-        <h1>Articles</h1>
-        <a class="backToMain" href="index.html">Home</a>
-        <ul>
-            <li><a href="app.html">Launch App</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="contact.html">Contact</a></li>
-        </ul>
+        <div class="headerBar">
+            <h1>Articles</h1>
+            <button class="hamburgerBtn" id="hamburgerBtn" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer">
+                <span></span><span></span><span></span>
+            </button>
+        </div>
+        <nav class="navDrawer" id="navDrawer" aria-hidden="true">
+            <button class="navDrawerClose" id="navDrawerClose" aria-label="Close menu">&times;</button>
+            <a class="backToMain" href="index.html">Home</a>
+            <ul>
+                <li><a href="app.html">Launch App</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="contact.html">Contact</a></li>
+            </ul>
+        </nav>
+        <div class="navOverlay" id="navOverlay"></div>
     </header>
 
     <div class="neck">
@@ -63,6 +72,7 @@
 </footer>
 
 <script src="articles-data.js"></script>
+<script src="nav.js"></script>
 <script src="articles.js"></script>
 
 </html>

--- a/contact.html
+++ b/contact.html
@@ -19,13 +19,22 @@
 
 <body>
     <header>
-        <h1>Contact</h1>
-        <a class="backToMain" href="index.html">Home</a>
-        <ul>
-            <li><a href="app.html">Launch App</a></li>
-            <li><a href="articles.html">Articles</a></li>
-            <li><a href="about.html">About</a></li>
-        </ul>
+        <div class="headerBar">
+            <h1>Contact</h1>
+            <button class="hamburgerBtn" id="hamburgerBtn" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer">
+                <span></span><span></span><span></span>
+            </button>
+        </div>
+        <nav class="navDrawer" id="navDrawer" aria-hidden="true">
+            <button class="navDrawerClose" id="navDrawerClose" aria-label="Close menu">&times;</button>
+            <a class="backToMain" href="index.html">Home</a>
+            <ul>
+                <li><a href="app.html">Launch App</a></li>
+                <li><a href="articles.html">Articles</a></li>
+                <li><a href="about.html">About</a></li>
+            </ul>
+        </nav>
+        <div class="navOverlay" id="navOverlay"></div>
     </header>
 
     <section class="demo">
@@ -48,6 +57,7 @@
         <p>Built by a dietitian, for dietitians (and the curious).</p>
     </footer>
 
+    <script src="nav.js"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -23,13 +23,22 @@
 
 <body>
     <header>
-        <h1>Food intolerance guide</h1>
-        <ul>
-            <li><a href="app.html">Launch App</a></li>
-            <li><a href="articles.html">Articles</a></li>
-            <li><a href="about.html">About</a></li>
-            <li><a href="contact.html">Contact</a></li>
-        </ul>
+        <div class="headerBar">
+            <h1>Food intolerance guide</h1>
+            <button class="hamburgerBtn" id="hamburgerBtn" aria-label="Open menu" aria-expanded="false" aria-controls="navDrawer">
+                <span></span><span></span><span></span>
+            </button>
+        </div>
+        <nav class="navDrawer" id="navDrawer" aria-hidden="true">
+            <button class="navDrawerClose" id="navDrawerClose" aria-label="Close menu">&times;</button>
+            <ul>
+                <li><a href="app.html">Launch App</a></li>
+                <li><a href="articles.html">Articles</a></li>
+                <li><a href="about.html">About</a></li>
+                <li><a href="contact.html">Contact</a></li>
+            </ul>
+        </nav>
+        <div class="navOverlay" id="navOverlay"></div>
     </header>
 
     <section class="hero">
@@ -78,6 +87,7 @@
     </footer>
 
     <script src="foods-data.js"></script>
+    <script src="nav.js"></script>
     <script src="landing.js"></script>
 </body>
 

--- a/nav.js
+++ b/nav.js
@@ -1,0 +1,80 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const header = document.querySelector("header");
+  const hamburgerBtn = document.getElementById("hamburgerBtn");
+  const navDrawer = document.getElementById("navDrawer");
+  const navOverlay = document.getElementById("navOverlay");
+  const navDrawerClose = document.getElementById("navDrawerClose");
+
+  if (!header || !hamburgerBtn || !navDrawer) return;
+
+  function openDrawer() {
+    navDrawer.classList.add("open");
+    if (navOverlay) navOverlay.classList.add("open");
+    hamburgerBtn.classList.add("open");
+    hamburgerBtn.setAttribute("aria-expanded", "true");
+    navDrawer.setAttribute("aria-hidden", "false");
+  }
+
+  function closeDrawer() {
+    navDrawer.classList.remove("open");
+    if (navOverlay) navOverlay.classList.remove("open");
+    hamburgerBtn.classList.remove("open");
+    hamburgerBtn.setAttribute("aria-expanded", "false");
+    navDrawer.setAttribute("aria-hidden", "true");
+  }
+
+  hamburgerBtn.addEventListener("click", function () {
+    if (navDrawer.classList.contains("open")) {
+      closeDrawer();
+    } else {
+      openDrawer();
+    }
+  });
+
+  if (navDrawerClose) navDrawerClose.addEventListener("click", closeDrawer);
+  if (navOverlay) navOverlay.addEventListener("click", closeDrawer);
+
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") closeDrawer();
+  });
+
+  navDrawer.querySelectorAll("a").forEach(function (link) {
+    link.addEventListener("click", closeDrawer);
+  });
+
+  // Header is fixed, so reserve the equivalent space at the top of the page.
+  function syncHeaderHeight() {
+    document.body.style.paddingTop = header.offsetHeight + "px";
+  }
+  syncHeaderHeight();
+  window.addEventListener("resize", syncHeaderHeight);
+
+  // Hide the header on scroll-down, reveal it on scroll-up or near the top.
+  let lastScrollY = window.scrollY;
+  let ticking = false;
+  const SCROLL_DELTA = 6;
+
+  function onScroll() {
+    const currentY = window.scrollY;
+
+    if (!navDrawer.classList.contains("open")) {
+      if (currentY <= 10) {
+        header.classList.remove("header--hidden");
+      } else if (currentY > lastScrollY + SCROLL_DELTA) {
+        header.classList.add("header--hidden");
+      } else if (currentY < lastScrollY - SCROLL_DELTA) {
+        header.classList.remove("header--hidden");
+      }
+    }
+
+    lastScrollY = currentY;
+    ticking = false;
+  }
+
+  window.addEventListener("scroll", function () {
+    if (!ticking) {
+      window.requestAnimationFrame(onScroll);
+      ticking = true;
+    }
+  }, { passive: true });
+});

--- a/styles.css
+++ b/styles.css
@@ -43,48 +43,147 @@ p {
     color: var(--ink);
 }
 
+body {
+    padding-top: 80px;
+}
+
 header {
     background: linear-gradient(180deg, var(--primary), var(--primary-dark));
-    padding: 16px 16px 6px;
+    padding: 14px 16px 10px;
     text-align: center;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 500;
+    transition: transform 0.3s ease;
 }
 
-.backToMain {
-    color: white;
-    display: block;
-    width: fit-content;
-    margin: 8px;
-    padding: 5px 14px;
-    font-size: 16px;
-    text-decoration: none;
-    border-radius: 8px;
+header.header--hidden {
+    transform: translateY(-100%);
 }
 
-.backToMain:hover {
-    background-color: var(--paper);
-    color: var(--primary);
-}
-
-header ul {
+.headerBar {
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+.headerBar h1 {
+    margin: 0;
+}
+
+/* Hamburger toggle button */
+.hamburgerBtn {
+    position: absolute;
+    right: 4px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 34px;
+    height: 26px;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+}
+
+.hamburgerBtn span {
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: 3px;
+    background: var(--linen);
+    border-radius: 2px;
+    transition: top 0.25s ease, transform 0.25s ease, opacity 0.25s ease;
+}
+
+.hamburgerBtn span:nth-child(1) { top: 0; }
+.hamburgerBtn span:nth-child(2) { top: 11px; }
+.hamburgerBtn span:nth-child(3) { top: 22px; }
+
+.hamburgerBtn.open span:nth-child(1) { top: 11px; transform: rotate(45deg); }
+.hamburgerBtn.open span:nth-child(2) { opacity: 0; }
+.hamburgerBtn.open span:nth-child(3) { top: 11px; transform: rotate(-45deg); }
+
+/* Off-canvas nav drawer */
+.navOverlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(12, 42, 49, 0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+    z-index: 900;
+}
+
+.navOverlay.open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.navDrawer {
+    position: fixed;
+    top: 0;
+    left: -340px;
+    width: 280px;
+    max-width: 80vw;
+    height: 100vh;
+    background: linear-gradient(180deg, var(--primary), var(--primary-dark));
+    box-shadow: 4px 0 30px rgba(0, 0, 0, 0.3);
+    z-index: 950;
+    padding: 70px 24px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    transition: left 0.3s ease;
+    overflow-y: auto;
+    text-align: left;
+}
+
+.navDrawer.open {
+    left: 0;
+}
+
+.navDrawerClose {
+    position: absolute;
+    top: 14px;
+    right: 16px;
+    background: none;
+    border: none;
+    color: var(--linen);
+    font-size: 28px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.navDrawer .backToMain {
+    margin: 0 0 12px;
+}
+
+.navDrawer ul {
+    display: flex;
+    flex-direction: column;
     list-style-type: none;
     margin: 0;
-    padding: 4px 0 8px;
-    background: transparent;
+    padding: 0;
+    gap: 4px;
 }
 
-header li a {
+.navDrawer li a,
+.navDrawer .backToMain {
     color: white;
     display: block;
-    margin: 4px;
-    padding: 5px 14px;
-    font-size: 16px;
+    padding: 10px 14px;
+    font-size: 18px;
     text-decoration: none;
     border-radius: 8px;
 }
 
-header li a:hover {
+.navDrawer li a:hover,
+.navDrawer .backToMain:hover {
     background-color: var(--paper);
     color: var(--primary);
 }
@@ -105,7 +204,7 @@ header li a:hover {
     display: flex;
     align-items: center;
     gap: 8px;
-    font-size: 15px;
+    font-size: 16px;
     font-weight: 600;
     accent-color: var(--sage-dark);
 }
@@ -115,7 +214,7 @@ header li a:hover {
     border: 1px solid var(--border);
     border-radius: 8px;
     padding: 4px 12px;
-    font-size: 14px;
+    font-size: 15px;
     text-decoration: none;
     color: var(--primary);
 }
@@ -173,6 +272,78 @@ header li a:hover {
     display: block;
     margin: 20px;
     text-align: center;
+}
+
+.instructionsBox {
+    max-width: 640px;
+    margin: 0 auto 24px;
+    padding: 18px 26px 10px;
+    background: var(--paper);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    text-align: left;
+}
+
+.instructionsBox h2 {
+    text-align: center;
+    margin-top: 0;
+}
+
+.stepsList {
+    list-style: none;
+    counter-reset: step;
+    margin: 0;
+    padding: 0;
+}
+
+.stepsList li {
+    counter-increment: step;
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 10px 0;
+}
+
+.stepsList li:not(:last-child) {
+    border-bottom: 1px solid var(--border);
+}
+
+.stepsList li::before {
+    content: counter(step);
+    flex: 0 0 auto;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: var(--sage);
+    color: white;
+    font-family: 'Source Sans Pro', sans-serif;
+    font-weight: 600;
+    font-size: 15px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.stepTitle {
+    display: block;
+    font-weight: 700;
+    font-size: 19px;
+    color: var(--primary);
+}
+
+.stepDetail {
+    display: block;
+    font-style: italic;
+    font-size: 15px;
+    color: var(--ink);
+    opacity: 0.85;
+    margin-top: 2px;
+}
+
+#chosenFoods {
+    border-top: 1px solid var(--border);
+    margin-top: 22px;
+    padding-top: 18px;
 }
 
 .neck ul {
@@ -316,7 +487,7 @@ input[type="checkbox"]:hover { cursor: pointer; }
     color: var(--primary-dark);
     text-decoration: underline;
     cursor: pointer;
-    font-size: 14px;
+    font-size: 15px;
     padding: 0;
     margin-bottom: 8px;
 }
@@ -324,7 +495,7 @@ input[type="checkbox"]:hover { cursor: pointer; }
 .popupMacroNote {
     font-style: italic;
     opacity: 0.85;
-    font-size: 14px;
+    font-size: 15px;
 }
 
 .popupContainer {
@@ -394,7 +565,7 @@ input[type="checkbox"]:hover { cursor: pointer; }
     width: 100%;
     font-family: 'Lora', serif;
     font-style: italic;
-    font-size: 16px;
+    font-size: 17px;
     color: var(--primary);
     font-weight: 600;
     margin: 16px 0 4px;
@@ -535,8 +706,6 @@ footer p { color: var(--linen); }
 
 @media only screen and (((max-device-width: 1024px) and (orientation:portrait)) or ((max-device-width: 896px) and (orientation:landscape)) or (max-width: 700px)) {
 
-    .backToMain { font-size: 4.5vw; }
-    header li a { font-size: 4.5vw; }
     h2 { font-size: 4.5vw; }
     p { font-size: 3.5vw; }
 
@@ -547,7 +716,7 @@ footer p { color: var(--linen); }
     .searchContainer input { font-size: 3vw; margin: 0 2vw 0 0; }
     .searchContainer button { font-size: 2.5vw; }
 
-    .topSection { margin: 6vw; margin-top: 12vw; padding: 2vw; margin-bottom: -2vw; }
+    .topSection { margin: 6vw; padding: 2vw; margin-bottom: -2vw; }
     .checkboxStyle { padding: 1vw; }
 
     .button { font-size: 3.5vw; margin: 0.5vw; padding: 2vw 4vw; }
@@ -566,8 +735,6 @@ footer p { color: var(--linen); }
 
 @media (min-width: 3800px) {
 
-    .backToMain { width: 12vw; font-size: 3.5vw; }
-    header li a { width: auto; font-size: 3.5vw; padding: 0.5vw 1vw; }
     h2 { font-size: 3.5vw; }
     p { font-size: 2.6vw; }
 
@@ -577,7 +744,7 @@ footer p { color: var(--linen); }
     .searchContainer input { font-size: 3vw; }
     .searchContainer button { font-size: 3vw; }
 
-    .topSection { margin: 6vw; margin-top: 12vw; padding: 2vw; margin-bottom: -2vw; }
+    .topSection { margin: 6vw; padding: 2vw; margin-bottom: -2vw; }
     .checkboxStyle { font-size: 4vw; padding: 2vw; }
 
     .button { font-size: 3.5vw; margin: 0.5vw; padding: 1vw 2vw; }
@@ -643,7 +810,7 @@ footer p { color: var(--linen); }
 }
 
 .demoDisclaimer {
-    font-size: 13px;
+    font-size: 15px;
     opacity: 0.75;
     font-style: italic;
     text-align: center;


### PR DESCRIPTION
…xt sizes

- Header nav collapses into a left slide-in drawer on every page; the header itself hides on scroll-down and reappears on scroll-up or near the top (nav.js, styles.css).
- Rework the app's step-by-step instructions into a numbered, boxed list with a bold headline and a smaller italic detail per step, separated from the "chosen foods" section by a divider.
- Nudge up the smallest text sizes (disclaimer bar, popup notes, filter headers, demo disclaimer) for readability.