### PR TITLE
Fix mobile text-size regression, restack instruction steps

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -17,8 +17,6 @@ html {
     background: linear-gradient(165deg, #f1ece0 0%, #e3e9de 55%, #d9e3da 100%);
     background-attachment: fixed;
     font-family: 'Source Sans Pro', sans-serif;
-    -webkit-text-size-adjust: 100%;
-    text-size-adjust: 100%;
 }
 
 body {
@@ -59,6 +57,11 @@ header {
     right: 0;
     z-index: 500;
     transition: transform 0.3s ease;
+    /* Stop mobile browsers auto-boosting the title font past its clamp()
+       size — scoped to the header only so the rest of the page keeps its
+       normal (and legible) mobile text sizing. */
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
 }
 
 header.header--hidden {
@@ -315,30 +318,11 @@ header.header--hidden {
 
 .stepsList li {
     counter-increment: step;
-    display: flex;
-    align-items: flex-start;
-    gap: 12px;
-    padding: 10px 0;
+    padding: 12px 0;
 }
 
 .stepsList li:not(:last-child) {
     border-bottom: 1px solid var(--border);
-}
-
-.stepsList li::before {
-    content: counter(step);
-    flex: 0 0 auto;
-    width: 26px;
-    height: 26px;
-    border-radius: 50%;
-    background: var(--sage);
-    color: white;
-    font-family: 'Source Sans Pro', sans-serif;
-    font-weight: 600;
-    font-size: 15px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
 }
 
 .stepTitle {
@@ -348,13 +332,24 @@ header.header--hidden {
     color: var(--primary);
 }
 
+.stepTitle::before {
+    content: counter(step) ". ";
+    color: var(--sage-dark);
+}
+
 .stepDetail {
     display: block;
     font-style: italic;
     font-size: 15px;
     color: var(--ink);
     opacity: 0.85;
-    margin-top: 2px;
+    margin-top: 4px;
+}
+
+.stepDetail::before {
+    content: "\2013";
+    font-style: normal;
+    margin-right: 5px;
 }
 
 #chosenFoods {


### PR DESCRIPTION
## Summary
- Scoped the mobile `text-size-adjust: 100%` fix (added to stop the header title overlapping the hamburger) to the `header` element only, instead of `html`. It was previously suppressing mobile browsers' normal font-boosting for body text everywhere, which made the already-small text (disclaimer bar, popup notes, filter headers) look smaller than before.
- Restacked the app's step-by-step instructions: each step is now a numbered bold title line, a dash-prefixed italic detail line underneath, and a divider between steps — instead of the number/title/detail sitting side by side in a row.

## Test plan
- [x] Verified via Playwright screenshots at desktop and mobile (412px) widths that the instructions now render as stacked numbered steps with dividers
- [x] Confirmed the header still doesn't overlap the hamburger button on mobile after scoping the text-size-adjust fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL55zr9aoZdKaqszoMXLFd)_