### PR TITLE
Deepen landing page demo with ranked shared traits

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,13 +52,17 @@
     </section>
 
     <section class="demo">
-        <h2>Try it — pick 2 or 3 foods</h2>
-        <p>This is a small taste of the real tool: eight foods, one shared trait. The full app tracks over 30
-            traits across 250+ foods.</p>
+        <h2>Try it — pick a few foods</h2>
+        <p>Six common foods that carry FODMAPs or histamine — pick at least two and see their top shared traits,
+            ranked by how many of your foods carry each one. The full app tracks over 30 traits across 250+
+            foods.</p>
 
         <div id="demoFoods" class="demoFoods"></div>
 
-        <div id="demoResult" class="demoResult">Select at least two foods to see what they share.</div>
+        <div id="demoResult" class="demoResult">
+            <p id="demoResultText">Select at least two foods to see what they share.</p>
+            <ul id="demoTraitList" class="demoTraitList"></ul>
+        </div>
 
         <p class="demoDisclaimer">This mini-demo is for illustration only, not medical advice — same as the full
             app. <a href="app.html">Read the full disclaimer</a> when you launch it.</p>

--- a/landing.js
+++ b/landing.js
@@ -1,9 +1,13 @@
 document.addEventListener("DOMContentLoaded", function () {
-  const DEMO_FOODS = ["Wheat", "Garlic", "Apples", "Cows Milk", "Shrimp", "Strawberry", "Coffee", "Peanut"];
-  const DEFAULT_CHECKED = ["Wheat", "Garlic", "Apples"];
+  // Six common foods that all carry FODMAPs and/or histamine, so most
+  // combinations turn up a meaningful shared trait.
+  const DEMO_FOODS = ["Wheat", "Garlic", "Onion", "Cows Milk", "Avocado", "Strawberry"];
+  const DEFAULT_CHECKED = ["Wheat", "Garlic", "Onion"];
+  const TOP_TRAITS_SHOWN = 3;
 
   const demoFoodsContainer = document.getElementById("demoFoods");
-  const demoResult = document.getElementById("demoResult");
+  const demoResultText = document.getElementById("demoResultText");
+  const demoTraitList = document.getElementById("demoTraitList");
 
   function findFoodTraits(name) {
     for (const category of CATEGORIES) {
@@ -26,26 +30,47 @@ document.addEventListener("DOMContentLoaded", function () {
     demoFoodsContainer.appendChild(label);
   });
 
-  function recomputeDemo() {
-    const checked = Array.from(demoFoodsContainer.querySelectorAll("input:checked")).map(function (cb) { return cb.value; });
-
-    if (checked.length < 2) {
-      demoResult.textContent = "Select at least two foods to see what they share.";
-      return;
-    }
-
-    const traitSets = checked.map(findFoodTraits);
-    const shared = traitSets[0].filter(function (trait) {
-      return traitSets.every(function (set) { return set.indexOf(trait) !== -1; });
+  // Ranks traits the same way the full app's summary does: how many of the
+  // selected foods carry each trait, shown as a percent of the selection.
+  function getRankedTraits(checked) {
+    const counts = {};
+    checked.forEach(function (name) {
+      findFoodTraits(name).forEach(function (traitId) {
+        counts[traitId] = (counts[traitId] || 0) + 1;
+      });
     });
 
-    if (shared.length === 0) {
-      demoResult.textContent = "These foods don't share a tracked trait — try a different combination.";
+    return Object.keys(counts)
+      .sort(function (a, b) { return counts[b] - counts[a]; })
+      .map(function (traitId) {
+        return { traitId: traitId, percent: Math.floor((counts[traitId] / checked.length) * 100) };
+      })
+      .slice(0, TOP_TRAITS_SHOWN);
+  }
+
+  function recomputeDemo() {
+    const checked = Array.from(demoFoodsContainer.querySelectorAll("input:checked")).map(function (cb) { return cb.value; });
+    demoTraitList.innerHTML = "";
+
+    if (checked.length < 2) {
+      demoResultText.textContent = "Select at least two foods to see what they share.";
       return;
     }
 
-    const label = TRAITS[shared[0]] ? TRAITS[shared[0]].label : shared[0];
-    demoResult.textContent = "These foods share: " + label + (shared.length > 1 ? " (and " + (shared.length - 1) + " more)" : "");
+    const topTraits = getRankedTraits(checked);
+
+    if (topTraits.length === 0) {
+      demoResultText.textContent = "These foods don't share a tracked trait — try a different combination.";
+      return;
+    }
+
+    demoResultText.textContent = "Top shared traits among these " + checked.length + " foods:";
+    topTraits.forEach(function (t) {
+      const li = document.createElement("li");
+      const label = TRAITS[t.traitId] ? TRAITS[t.traitId].label : t.traitId;
+      li.textContent = t.percent + "% — " + label;
+      demoTraitList.appendChild(li);
+    });
   }
 
   recomputeDemo();

--- a/styles.css
+++ b/styles.css
@@ -815,14 +815,30 @@ footer p { color: var(--linen); }
 }
 
 .demoResult {
-    font-size: 18px;
-    font-weight: bold;
     color: var(--primary-dark);
     background: var(--linen);
     border-radius: 10px;
-    padding: 14px;
+    padding: 14px 18px;
     margin: 20px 0;
     min-height: 24px;
+}
+
+#demoResultText {
+    font-size: 18px;
+    font-weight: bold;
+    margin: 0;
+}
+
+.demoTraitList {
+    list-style: none;
+    margin: 8px 0 0;
+    padding: 0;
+}
+
+.demoTraitList li {
+    font-size: 17px;
+    font-weight: 600;
+    padding: 3px 0;
 }
 
 .demoDisclaimer {


### PR DESCRIPTION
## Summary
- Swapped the landing page demo's food list for six common foods that all carry FODMAPs and/or histamine (Wheat, Garlic, Onion, Cows Milk, Avocado, Strawberry).
- Replaced the old "first shared trait" result with the same ranking logic the full app's summary panel uses: count how many of the selected foods carry each trait, rank by that count, and show the top three as a percent of the selection.

## Test plan
- [x] Verified via Playwright that the default selection (Wheat, Garlic, Onion) shows 100% FODMAPs / Fructans / Histamine
- [x] Verified a different combination (Wheat, Garlic, Avocado, Strawberry) shows a different, correctly-ranked top three
- [x] Checked layout on desktop and a 412px mobile viewport


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL55zr9aoZdKaqszoMXLFd)_