### PR TITLE
Rename broad trait labels: Allergy, Irritant

### DIFF
--- a/foods-data.js
+++ b/foods-data.js
@@ -227,7 +227,7 @@ const TRAITS = {
   /* ---- Irritant: broad trait + specific mechanisms (additive) ---- */
   irritant: {
     order: 5,
-    label: "General",
+    label: "Irritant",
     filter: true,
     articleId: "irritant",
     analysis: [
@@ -287,7 +287,7 @@ const TRAITS = {
   /* ---- Allergen: broad "Big 9" trait + specific allergens (additive) ---- */
   allergen: {
     order: 9,
-    label: "Big 9 (general)",
+    label: "Allergy",
     filter: true,
     articleId: "allergen",
     analysis: [


### PR DESCRIPTION
## Summary
- Renamed the `allergen` trait's label from "Big 9 (general)" to "Allergy".
- Renamed the `irritant` trait's label from "General" to "Irritant".
- Both labels are defined once in `TRAITS` (foods-data.js), so the rename automatically covers the filter checkbox list, the analysis popup heading, and the landing page demo.

## Test plan
- [x] Verified via Playwright that the filter list renders "Allergy" and "Irritant" instead of the old labels


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL55zr9aoZdKaqszoMXLFd)_