### PR TITLE
Rename cross_reactive label to Cross-reaction

### DIFF
--- a/foods-data.js
+++ b/foods-data.js
@@ -380,7 +380,7 @@ const TRAITS = {
   /* ---- Cross-reactive: broad OAS trait + specific pollen syndromes ---- */
   cross_reactive: {
     order: 10,
-    label: "General (OAS)",
+    label: "Cross-reaction",
     filter: true,
     articleId: "cross_reactive",
     analysis: [


### PR DESCRIPTION
## Summary
- Renamed the `cross_reactive` trait's label from "General (OAS)" to "Cross-reaction".

## Test plan
- [x] Single-field data change in `TRAITS` (foods-data.js); covers filter list, analysis popup, and demo automatically


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL55zr9aoZdKaqszoMXLFd)_