### PR TITLE
Rebuild filter list as grouped cards

### DIFF
--- a/foods-data.js
+++ b/foods-data.js
@@ -74,6 +74,35 @@
      { name: "Jackfruit", traits: ["fiber", "carbs"] }
 
    That's it — no HTML, CSS, or JS changes needed anywhere else.
+
+   ---------------------------------------------------------------------
+   FILTER LIST LAYOUT (the cards under "Filter Analysis" in the app)
+   ---------------------------------------------------------------------
+   FILTER_SECTIONS (below TRAITS) controls how filterable traits are
+   grouped into cards, independent of any food/trait data. Each entry:
+
+     {
+       title: "Card heading",
+       broad: "traitId",   // optional — rendered as the card's bold parent
+                            // checkbox (usually a "broad" trait, see above)
+       group: "GroupName", // optional — pulls every trait whose `group`
+                            // matches, sorted by `order`, indented under
+                            // the broad checkbox
+       items: ["traitId"], // optional — extra standalone checkboxes with no
+                            // broad/specific nesting (or the card's only
+                            // content, if `broad`/`group` are omitted)
+       wide: true           // optional — card spans both grid columns
+     }
+
+   A new trait with `filter: true` needs to be added to one of these
+   sections (via `group` or `items`) to actually show up in the filter
+   list — TRAITS alone only makes it filterable in principle.
+
+   Fat, Protein and Carbohydrates are deliberately NOT filterable and
+   don't appear in any section — they're tracked in the background and
+   only ever surface as an automatic side note in the analysis popup when
+   over 90% of the selected foods share one (see MACRO_TRAIT_IDS in
+   script.js). Leave them out of FILTER_SECTIONS.
    ========================================================================= */
 
 const TRAITS = {
@@ -426,6 +455,37 @@ const TRAITS = {
     ]
   }
 };
+
+/* See "FILTER LIST LAYOUT" in the comment block above for the shape of
+   each entry. */
+const FILTER_SECTIONS = [
+  {
+    title: "GI Irritants",
+    broad: "irritant",
+    group: "GI Irritants"
+  },
+  {
+    title: "FODMAPs",
+    broad: "fodmaps",
+    group: "FODMAPs"
+  },
+  {
+    title: "Other Digestive Factors",
+    items: ["fiber", "histamine", "bile_stimulant"]
+  },
+  {
+    title: "Allergens",
+    broad: "allergen",
+    group: "Allergens"
+  },
+  {
+    title: "Cross-Reactivity & Delayed Allergy",
+    broad: "cross_reactive",
+    group: "Cross-reactivity",
+    items: ["alpha_gal"],
+    wide: true
+  }
+];
 
 const CATEGORIES = [
   {

--- a/script.js
+++ b/script.js
@@ -102,28 +102,11 @@
     });
   }
 
-  // ---- Build the filter checkboxes from TRAITS --------------------------
+  // ---- Build the filter checkboxes from FILTER_SECTIONS / TRAITS --------
   function renderFilters() {
-    const BROAD_TO_SUBGROUP = {
-      irritant: "GI Irritants",
-      fodmaps: "FODMAPs",
-      allergen: "Allergens",
-      cross_reactive: "Cross-reactivity"
-    };
-
-    const grouped = {};
-    const ungrouped = [];
-    Object.keys(TRAITS).forEach(function (traitId) {
-      const trait = TRAITS[traitId];
-      if (!trait.filter) return;
-      if (!trait.group) { ungrouped.push({ traitId, trait }); return; }
-      if (!grouped[trait.group]) grouped[trait.group] = [];
-      grouped[trait.group].push({ traitId, trait });
-    });
-
-    function renderCheckbox(container, traitId, trait) {
+    function renderCheckbox(container, traitId, trait, extraClass) {
       const label = document.createElement("label");
-      label.className = "checkboxStyle";
+      label.className = extraClass ? "checkboxStyle " + extraClass : "checkboxStyle";
       const checkbox = document.createElement("input");
       checkbox.type = "checkbox";
       checkbox.value = traitId;
@@ -133,36 +116,46 @@
       container.appendChild(label);
     }
 
-    function renderSubgroup(groupName) {
-      const items = grouped[groupName];
-      if (!items) return;
-      const header = document.createElement("p");
-      header.className = "filterGroupHeader";
-      header.textContent = groupName;
-      header.setAttribute("aria-expanded", "false");
-      filterContainer.appendChild(header);
-
-      const groupWrap = document.createElement("div");
-      groupWrap.className = "filterGroup collapsed";
-      items
-        .sort(function (a, b) { return (a.trait.order || 99) - (b.trait.order || 99); })
-        .forEach(function (item) { renderCheckbox(groupWrap, item.traitId, item.trait); });
-      filterContainer.appendChild(groupWrap);
-
-      header.addEventListener("click", function () {
-        const expanded = header.getAttribute("aria-expanded") === "true";
-        header.setAttribute("aria-expanded", !expanded);
-        groupWrap.classList.toggle("collapsed", expanded);
-      });
+    function getGroupTraits(groupName) {
+      return Object.keys(TRAITS)
+        .filter(function (id) { return TRAITS[id].filter && TRAITS[id].group === groupName; })
+        .map(function (id) { return { traitId: id, trait: TRAITS[id] }; })
+        .sort(function (a, b) { return (a.trait.order || 99) - (b.trait.order || 99); });
     }
 
-    ungrouped
-      .sort(function (a, b) { return (a.trait.order || 99) - (b.trait.order || 99); })
-      .forEach(function (item) {
-        renderCheckbox(filterContainer, item.traitId, item.trait);
-        const subgroupName = BROAD_TO_SUBGROUP[item.traitId];
-        if (subgroupName) renderSubgroup(subgroupName);
-      });
+    FILTER_SECTIONS.forEach(function (section) {
+      const card = document.createElement("div");
+      card.className = section.wide ? "filterCard wide" : "filterCard";
+
+      const title = document.createElement("p");
+      title.className = "filterCardTitle";
+      title.textContent = section.title;
+      card.appendChild(title);
+
+      if (section.broad) {
+        renderCheckbox(card, section.broad, TRAITS[section.broad], "broad");
+      }
+
+      if (section.group) {
+        const specificWrap = document.createElement("div");
+        specificWrap.className = "specificWrap checkRow";
+        getGroupTraits(section.group).forEach(function (item) {
+          renderCheckbox(specificWrap, item.traitId, item.trait);
+        });
+        card.appendChild(specificWrap);
+      }
+
+      if (section.items) {
+        const row = document.createElement("div");
+        row.className = section.group ? "checkRow extraRow" : "checkRow";
+        section.items.forEach(function (traitId) {
+          renderCheckbox(row, traitId, TRAITS[traitId]);
+        });
+        card.appendChild(row);
+      }
+
+      filterContainer.appendChild(card);
+    });
   }
 
   // ---- Read current state straight from the DOM ------------------------

--- a/styles.css
+++ b/styles.css
@@ -563,55 +563,66 @@ input[type="checkbox"]:hover { cursor: pointer; }
 }
 
 .filterContainer {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    width: min(60%, 600px);
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+    width: min(85%, 780px);
     margin: 0 auto;
     padding: 0;
+    text-align: left;
 }
 
-.filterContainer label { width: fit-content; }
+.filterCard {
+    background: var(--paper);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 16px 18px;
+}
 
-.filterGroupHeader {
-    width: 100%;
+.filterCard.wide {
+    grid-column: 1 / -1;
+}
+
+.filterCardTitle {
     font-family: 'Lora', serif;
     font-style: italic;
+    font-weight: 600;
     font-size: 17px;
     color: var(--primary);
-    font-weight: 600;
-    margin: 16px 0 4px;
-    padding-bottom: 3px;
+    margin: 0 0 10px;
+    padding-bottom: 8px;
     border-bottom: 1px solid var(--border);
-    cursor: pointer;
-    user-select: none;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
 }
 
-.filterGroupHeader::after {
-    content: '▸';
-    font-style: normal;
-    font-size: 12px;
-    transition: transform 0.2s ease;
-}
-
-.filterGroupHeader[aria-expanded="true"]::after {
-    transform: rotate(90deg);
-}
-
-.filterGroup {
-    width: 100%;
+.checkRow {
     display: flex;
     flex-wrap: wrap;
-    overflow: hidden;
-    max-height: 600px;
-    transition: max-height 0.25s ease;
 }
 
-.filterGroup.collapsed {
-    max-height: 0;
+.checkRow.extraRow {
+    margin-top: 10px;
+}
+
+.checkboxStyle.broad {
+    font-weight: 700;
+    color: var(--primary);
+}
+
+.specificWrap {
+    margin: 10px 0 0 6px;
+    padding: 8px 0 0 16px;
+    border-left: 3px solid var(--sage);
+}
+
+.specificWrap .checkboxStyle {
+    font-size: 18px;
+}
+
+@media (max-width: 700px) {
+    .filterContainer {
+        grid-template-columns: 1fr;
+        width: min(94%, 600px);
+    }
 }
 
 /* ---- articles.html ---- */


### PR DESCRIPTION
## Summary
- Added `FILTER_SECTIONS` to `foods-data.js`: a small config describing which titled card each filterable trait belongs to, and whether it has a broad "parent" checkbox with nested specifics beneath it. Documented in the file's existing comment block so future trait additions stay a data-only edit.
- Rewrote `renderFilters()` in `script.js` to render from `FILTER_SECTIONS` — one card per family (GI Irritants, FODMAPs, Other Digestive Factors, Allergens, Cross-Reactivity & Delayed Allergy), broad checkbox above its indented specifics, always expanded instead of the old collapsible-accordion-in-a-flex-row layout. The filtering logic itself (`recompute`, `getExcludedTraitIds`, Clear Filters) is unchanged.
- Replaced the old filter CSS with a 2-column card grid that collapses to 1 column on mobile.
- Fat, Protein and Carbohydrates are deliberately left out of `FILTER_SECTIONS` — they stay background-only and continue to surface only as the automatic macro side note in the analysis popup, same as before.

## Test plan
- [x] Verified via Playwright that selecting a food and toggling a filter checkbox (e.g. excluding FODMAPs) still correctly updates the summary/ranked traits
- [x] Verified "Clear Filters" still unchecks all filter checkboxes and restores the full trait list
- [x] Checked the card grid layout on desktop (2 columns) and a 412px mobile viewport (1 column)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL55zr9aoZdKaqszoMXLFd)_