### PR TITLE
Add pre-beta version number and update footer dates

### DIFF
--- a/about.html
+++ b/about.html
@@ -110,6 +110,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
+        <p>Pre-beta v0.2 — updated July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/app.html
+++ b/app.html
@@ -155,7 +155,8 @@
     <p>Did you find this webpage useful?</p>
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
-    <p>Uppsala, Sweden, 2024</p>
+    <p>Uppsala, Sweden, 2026</p>
+    <p>Pre-beta v0.2 — updated July 2026</p>
 </footer>
 
 <script src="foods-data.js"></script>

--- a/articles.html
+++ b/articles.html
@@ -68,7 +68,8 @@
     <p>Did you find this webpage useful?</p>
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
-    <p>Uppsala, Sweden, 2024</p>
+    <p>Uppsala, Sweden, 2026</p>
+    <p>Pre-beta v0.2 — updated July 2026</p>
 </footer>
 
 <script src="articles-data.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -55,6 +55,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
+        <p>Pre-beta v0.2 — updated July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
+        <p>Pre-beta v0.2 — updated July 2026</p>
     </footer>
 
     <script src="foods-data.js"></script>


### PR DESCRIPTION
Adds "Pre-beta v0.2 — updated July 2026" to the footer on all five pages, and updates the "Uppsala, Sweden, 2024" lines to 2026.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL55zr9aoZdKaqszoMXLFd)_