### PR TITLE
Fix typo, removable chosen foods, grouped categories, live analysis popup

### DIFF
--- a/app.html
+++ b/app.html
@@ -97,7 +97,7 @@
         </div>
         <div id="chosenFoods">
             <h2>Chosen items:</h2>
-            <p id="chosenText">Click on a category to show lists of foods</p>
+            <div id="chosenText">Click on a category to show lists of foods</div>
         </div>
         <div class="searchContainer" id="searchContainer">
             <input type="text" id="search" placeholder="Filter food list...">
@@ -137,7 +137,7 @@
         <div id="printFoodsList" class="printOnly"></div>
         <div id="printArticlesList" class="printOnly"></div>
 
-        <button class="button2 noPrint" id="showAnalysisButton" name="Show Analysis Popup">Show Anlysis</button>
+        <button class="button2 noPrint" id="showAnalysisButton" name="Show Analysis Popup">Show Analysis</button>
         <button class="button2 noPrint" id="restartButton" name="Restart">Restart</button>
 
         <h2 class="noPrint">Filter Analysis</h2>

--- a/foods-data.js
+++ b/foods-data.js
@@ -75,6 +75,11 @@
 
    That's it — no HTML, CSS, or JS changes needed anywhere else.
 
+   A new category should also be listed under a group in CATEGORY_GROUPS
+   below (just its `id`, in whichever group it fits best) so it's shown
+   next to related categories instead of on its own. If you forget, it
+   still renders — grouped at the end under "Other".
+
    ---------------------------------------------------------------------
    FILTER LIST LAYOUT (the cards under "Filter Analysis" in the app)
    ---------------------------------------------------------------------
@@ -902,5 +907,32 @@ const CATEGORIES = [
       { name: "Olives", traits: ["over_10g_fat", "histamine"] },
       { name: "Miso Paste", traits: ["histamine", "allergen", "allergen_soy", "fodmaps"] }
     ]
+  }
+];
+
+/* Groups the category buttons under "Choose foods" into labeled clusters.
+   List category `id`s (from CATEGORIES above), not labels. Any category id
+   not listed here still renders, grouped under a trailing "Other" section —
+   see FOOD_CATEGORY logic in script.js. */
+const CATEGORY_GROUPS = [
+  {
+    title: "Produce",
+    categories: ["roots", "veggies", "fruits", "berries", "mushrooms"]
+  },
+  {
+    title: "Grains, Legumes & Nuts",
+    categories: ["grains", "legumes", "nuts"]
+  },
+  {
+    title: "Animal-Based",
+    categories: ["landAnimals", "seafood", "dairy"]
+  },
+  {
+    title: "Flavor & Extras",
+    categories: ["spices", "condiments", "sauces", "picklesFerments"]
+  },
+  {
+    title: "Processed & Beverages",
+    categories: ["ultraProcessed", "snacksSweets", "beverages"]
   }
 ];

--- a/script.js
+++ b/script.js
@@ -31,9 +31,6 @@
   const popupContainer = document.getElementById("popupContainer");
   const popupTextContainer = document.getElementById("popupTextContainer");
 
-  let lastTopTraits = [];
-  let lastMacroNotes = [];
-
   // ---- Disclaimer popup close-on-click -----------------------------------
   const disclaimerPopup = document.getElementById("disclaimerPopup");
   const disclaimerBtn = document.querySelector(".disclaimerBtn");
@@ -63,9 +60,9 @@
     }
   });
 
-  // ---- Build the food category boxes from CATEGORIES -------------------
+  // ---- Build the food category boxes from CATEGORIES / CATEGORY_GROUPS --
   function renderCategories() {
-    CATEGORIES.forEach(function (category) {
+    function renderCategoryBox(container, category) {
       const box = document.createElement("div");
       box.className = "foodBox";
 
@@ -98,8 +95,55 @@
 
       box.appendChild(button);
       box.appendChild(group);
-      topSection.appendChild(box);
+      container.appendChild(box);
+    }
+
+    const byId = {};
+    CATEGORIES.forEach(function (category) { byId[category.id] = category; });
+    const placedIds = new Set();
+
+    CATEGORY_GROUPS.forEach(function (categoryGroup) {
+      const categories = categoryGroup.categories
+        .map(function (id) { return byId[id]; })
+        .filter(Boolean);
+      if (categories.length === 0) return;
+
+      const section = document.createElement("div");
+      section.className = "categoryGroup";
+
+      const title = document.createElement("p");
+      title.className = "categoryGroupTitle";
+      title.textContent = categoryGroup.title;
+      section.appendChild(title);
+
+      const row = document.createElement("div");
+      row.className = "categoryGroupRow";
+      categories.forEach(function (category) {
+        placedIds.add(category.id);
+        renderCategoryBox(row, category);
+      });
+      section.appendChild(row);
+
+      topSection.appendChild(section);
     });
+
+    const leftover = CATEGORIES.filter(function (category) { return !placedIds.has(category.id); });
+    if (leftover.length > 0) {
+      const section = document.createElement("div");
+      section.className = "categoryGroup";
+
+      const title = document.createElement("p");
+      title.className = "categoryGroupTitle";
+      title.textContent = "Other";
+      section.appendChild(title);
+
+      const row = document.createElement("div");
+      row.className = "categoryGroupRow";
+      leftover.forEach(function (category) { renderCategoryBox(row, category); });
+      section.appendChild(row);
+
+      topSection.appendChild(section);
+    }
   }
 
   // ---- Build the filter checkboxes from FILTER_SECTIONS / TRAITS --------
@@ -170,6 +214,37 @@
     });
   }
 
+  // Renders each chosen food as a chip with its own remove (×) button, wired
+  // directly to the checkbox that put it there so removal always finds the
+  // right one, even if two foods share a name substring.
+  function renderChosenFoods() {
+    const checkboxes = Array.from(topSection.querySelectorAll("input[type='checkbox']:checked"));
+    chosenText.innerHTML = "";
+
+    if (checkboxes.length === 0) {
+      chosenText.textContent = "Click on a category to show lists of foods";
+      return;
+    }
+
+    checkboxes.forEach(function (checkbox) {
+      const chip = document.createElement("span");
+      chip.className = "chosenFoodChip";
+      chip.appendChild(document.createTextNode(checkbox.value));
+
+      const removeBtn = document.createElement("button");
+      removeBtn.type = "button";
+      removeBtn.className = "chosenFoodRemove";
+      removeBtn.setAttribute("aria-label", "Remove " + checkbox.value);
+      removeBtn.textContent = "×";
+      removeBtn.addEventListener("click", function () {
+        checkbox.checked = false;
+        recompute();
+      });
+      chip.appendChild(removeBtn);
+      chosenText.appendChild(chip);
+    });
+  }
+
   function getExcludedTraitIds() {
     const checked = filterContainer.querySelectorAll("input[type='checkbox']:checked");
     return new Set(Array.from(checked).map(function (checkbox) {
@@ -201,9 +276,7 @@
     const selectedFoods = getSelectedFoods();
     const excluded = getExcludedTraitIds();
 
-    chosenText.textContent = selectedFoods.length
-      ? selectedFoods.map(function (f) { return f.name; }).join(", ")
-      : "Click on a category to show lists of foods";
+    renderChosenFoods();
 
     const counts = {};
     selectedFoods.forEach(function (food) {
@@ -215,8 +288,6 @@
     });
 
     const allTraits = getRankedTraits(counts, selectedFoods.length);
-    lastTopTraits = allTraits.slice(0, 3);
-    lastMacroNotes = getMacroNotes(counts, selectedFoods.length);
     updateSummaryText(selectedFoods.length, allTraits);
   }
 
@@ -274,71 +345,175 @@
   });
 
   // ---- Analysis popup ----------------------------------------------------
-  showAnalysisButton.addEventListener("click", function () {
+  // The popup keeps its own live, self-contained view: all selected foods
+  // are listed and can be toggled out of the analysis one at a time without
+  // touching the real selection (so they're easy to bring back), and each
+  // shown trait can be excluded on the spot — which reuses the real filter
+  // checkbox, so it stays in sync with the main Filter Analysis section.
+  let popupAllFoods = [];
+  let popupExcludedFoods = new Set();
+  let popupActiveFoods = [];
+  let popupActiveTraits = [];
+
+  function renderPopupAnalysis() {
     popupTextContainer.innerHTML = "";
 
-    if (lastTopTraits.length === 0) {
+    if (popupAllFoods.length === 0) {
+      popupActiveFoods = [];
+      popupActiveTraits = [];
       const p = document.createElement("p");
       p.className = "popupText";
       p.textContent = "Select foods to see a deeper summary and analysis of the foods.";
       popupTextContainer.appendChild(p);
-    } else {
-      lastTopTraits.forEach(function (item, index) {
-        if (index > 0) {
-          const hr = document.createElement("hr");
-          hr.className = "popupDivider";
-          popupTextContainer.appendChild(hr);
-        }
-        const trait = TRAITS[item.traitId];
-        const heading = document.createElement("p");
-        heading.className = "popupTraitHeading";
-        heading.textContent = item.percent + "% — " + trait.label;
-        popupTextContainer.appendChild(heading);
-        const paragraphs = (trait.analysis && trait.analysis.length)
-          ? trait.analysis
-          : ["The most common shared trait among these foods is " + trait.label + "."];
-        paragraphs.forEach(function (text, i) {
-          const p = document.createElement("p");
-          if (i === 0) p.className = "popupText";
-          p.textContent = text;
-          popupTextContainer.appendChild(p);
-        });
-        if (trait.articleId) {
-          const p = document.createElement("p");
-          p.className = "noPrint";
-          const link = document.createElement("a");
-          link.href = "articles.html#" + trait.articleId;
-          link.target = "_blank";
-          link.rel = "noopener";
-          link.textContent = "Read the full article →";
-          link.addEventListener("click", function (e) { e.stopPropagation(); });
-          p.appendChild(link);
-          popupTextContainer.appendChild(p);
+      return;
+    }
 
-          const printNote = document.createElement("p");
-          printNote.className = "printOnly";
-          const articleTitle = (typeof ARTICLES !== "undefined" && ARTICLES[trait.articleId])
-            ? ARTICLES[trait.articleId].title : trait.label;
-          printNote.textContent = "See \"" + articleTitle + "\" below.";
-          popupTextContainer.appendChild(printNote);
-        }
+    const activeFoods = popupAllFoods.filter(function (food) { return !popupExcludedFoods.has(food.name); });
+    const excludedTraitIds = getExcludedTraitIds();
+    const counts = {};
+    activeFoods.forEach(function (food) {
+      food.traits.forEach(function (traitId) {
+        if (excludedTraitIds.has(traitId)) return;
+        if (!TRAITS[traitId]) return;
+        counts[traitId] = (counts[traitId] || 0) + 1;
       });
+    });
+    const topTraits = getRankedTraits(counts, activeFoods.length, 3);
+    const macroNotes = getMacroNotes(counts, activeFoods.length);
 
-      if (lastMacroNotes.length > 0) {
+    popupActiveFoods = activeFoods;
+    popupActiveTraits = topTraits;
+
+    const foodsIntro = document.createElement("p");
+    foodsIntro.className = "popupFoodsIntro noPrint";
+    foodsIntro.textContent = "Foods in this analysis — click one to leave it out, click again to bring it back:";
+    popupTextContainer.appendChild(foodsIntro);
+
+    const chipRow = document.createElement("div");
+    chipRow.className = "popupFoodChips noPrint";
+    popupAllFoods.forEach(function (food) {
+      const isExcluded = popupExcludedFoods.has(food.name);
+      const chip = document.createElement("button");
+      chip.type = "button";
+      chip.className = isExcluded ? "popupFoodChip excluded" : "popupFoodChip";
+      chip.textContent = food.name;
+      chip.setAttribute("aria-pressed", String(!isExcluded));
+      chip.addEventListener("click", function (e) {
+        e.stopPropagation();
+        if (isExcluded) popupExcludedFoods.delete(food.name);
+        else popupExcludedFoods.add(food.name);
+        renderPopupAnalysis();
+      });
+      chipRow.appendChild(chip);
+    });
+    popupTextContainer.appendChild(chipRow);
+
+    const introHr = document.createElement("hr");
+    introHr.className = "popupDivider";
+    popupTextContainer.appendChild(introHr);
+
+    if (activeFoods.length === 0) {
+      const p = document.createElement("p");
+      p.className = "popupText";
+      p.textContent = "Every food above is left out of the analysis right now — click one to bring it back.";
+      popupTextContainer.appendChild(p);
+      return;
+    }
+
+    if (topTraits.length === 0) {
+      const p = document.createElement("p");
+      p.className = "popupText";
+      p.textContent = "These foods don't share a tracked trait right now (or every relevant factor is excluded).";
+      popupTextContainer.appendChild(p);
+      return;
+    }
+
+    topTraits.forEach(function (item, index) {
+      if (index > 0) {
         const hr = document.createElement("hr");
         hr.className = "popupDivider";
         popupTextContainer.appendChild(hr);
-        const note = document.createElement("p");
-        note.className = "popupMacroNote";
-        const joined = lastMacroNotes.length > 1
-          ? lastMacroNotes.slice(0, -1).join(", ") + " and " + lastMacroNotes[lastMacroNotes.length - 1]
-          : lastMacroNotes[0];
-        note.textContent = "Note: this selection is also high in " + joined +
-          " (over 90% of foods) — these rarely cause symptoms directly but can worsen other GI issues.";
-        popupTextContainer.appendChild(note);
       }
-    }
+      const trait = TRAITS[item.traitId];
 
+      const headingRow = document.createElement("div");
+      headingRow.className = "popupTraitHeadingRow";
+
+      const heading = document.createElement("p");
+      heading.className = "popupTraitHeading";
+      heading.textContent = item.percent + "% — " + trait.label;
+      headingRow.appendChild(heading);
+
+      const removeBtn = document.createElement("button");
+      removeBtn.type = "button";
+      removeBtn.className = "popupTraitRemove noPrint";
+      removeBtn.textContent = "Exclude";
+      removeBtn.setAttribute("aria-label", "Exclude " + trait.label + " from the analysis");
+      removeBtn.addEventListener("click", function (e) {
+        e.stopPropagation();
+        const filterCheckbox = filterContainer.querySelector('input[value="' + item.traitId + '"]');
+        if (filterCheckbox) {
+          filterCheckbox.checked = true;
+          recompute();
+        }
+        renderPopupAnalysis();
+      });
+      headingRow.appendChild(removeBtn);
+
+      popupTextContainer.appendChild(headingRow);
+
+      const paragraphs = (trait.analysis && trait.analysis.length)
+        ? trait.analysis
+        : ["The most common shared trait among these foods is " + trait.label + "."];
+      paragraphs.forEach(function (text, i) {
+        const p = document.createElement("p");
+        if (i === 0) p.className = "popupText";
+        p.textContent = text;
+        popupTextContainer.appendChild(p);
+      });
+      if (trait.articleId) {
+        const p = document.createElement("p");
+        p.className = "noPrint";
+        const link = document.createElement("a");
+        link.href = "articles.html#" + trait.articleId;
+        link.target = "_blank";
+        link.rel = "noopener";
+        link.textContent = "Read the full article →";
+        link.addEventListener("click", function (e) { e.stopPropagation(); });
+        p.appendChild(link);
+        popupTextContainer.appendChild(p);
+
+        const printNote = document.createElement("p");
+        printNote.className = "printOnly";
+        const articleTitle = (typeof ARTICLES !== "undefined" && ARTICLES[trait.articleId])
+          ? ARTICLES[trait.articleId].title : trait.label;
+        printNote.textContent = "See \"" + articleTitle + "\" below.";
+        popupTextContainer.appendChild(printNote);
+      }
+    });
+
+    if (macroNotes.length > 0) {
+      const hr = document.createElement("hr");
+      hr.className = "popupDivider";
+      popupTextContainer.appendChild(hr);
+      const note = document.createElement("p");
+      note.className = "popupMacroNote";
+      const joined = macroNotes.length > 1
+        ? macroNotes.slice(0, -1).join(", ") + " and " + macroNotes[macroNotes.length - 1]
+        : macroNotes[0];
+      note.textContent = "Note: this selection is also high in " + joined +
+        " (over 90% of foods) — these rarely cause symptoms directly but can worsen other GI issues.";
+      popupTextContainer.appendChild(note);
+    }
+  }
+
+  showAnalysisButton.addEventListener("click", function () {
+    const opening = !popupContainer.classList.contains("show");
+    if (opening) {
+      popupAllFoods = getSelectedFoods();
+      popupExcludedFoods = new Set();
+      renderPopupAnalysis();
+    }
     popupContainer.classList.toggle("show");
   });
 
@@ -349,9 +524,9 @@
   document.getElementById("printAnalysisButton").addEventListener("click", function (e) {
     e.stopPropagation();
 
-    const foods = getSelectedFoods().map(function (f) { return f.name; }).sort();
+    const foods = popupActiveFoods.map(function (f) { return f.name; }).sort();
     const foodsList = document.getElementById("printFoodsList");
-    foodsList.innerHTML = "<h2>Selected foods (" + foods.length + ")</h2>";
+    foodsList.innerHTML = "<h2>Foods in this analysis (" + foods.length + ")</h2>";
     const ul = document.createElement("ul");
     ul.className = "printFoodsUl";
     foods.forEach(function (name) {
@@ -365,7 +540,7 @@
     articlesBox.innerHTML = "";
     if (typeof ARTICLES !== "undefined") {
       const seen = new Set();
-      lastTopTraits.forEach(function (item) {
+      popupActiveTraits.forEach(function (item) {
         const trait = TRAITS[item.traitId];
         if (!trait.articleId || seen.has(trait.articleId)) return;
         const article = ARTICLES[trait.articleId];

--- a/styles.css
+++ b/styles.css
@@ -358,6 +358,46 @@ header.header--hidden {
     padding-top: 18px;
 }
 
+#chosenText {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
+}
+
+.chosenFoodChip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--linen);
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    padding: 4px 6px 4px 14px;
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--ink);
+}
+
+.chosenFoodRemove {
+    background: var(--clay);
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 22px;
+    height: 22px;
+    line-height: 1;
+    font-size: 15px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+}
+
+.chosenFoodRemove:hover {
+    background: var(--clay-dark);
+}
+
 .neck ul {
     float: none;
     position: relative;
@@ -393,9 +433,27 @@ header.header--hidden {
 }
 
 .topSection {
+    margin: 75px;
+}
+
+.categoryGroup {
+    margin-bottom: 26px;
+}
+
+.categoryGroupTitle {
+    font-family: 'Lora', serif;
+    font-style: italic;
+    font-weight: 600;
+    font-size: 18px;
+    color: var(--primary);
+    margin: 0 0 10px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--border);
+}
+
+.categoryGroupRow {
     display: flex;
     flex-wrap: wrap;
-    margin: 75px;
 }
 
 .foodBox {
@@ -555,6 +613,91 @@ input[type="checkbox"]:hover { cursor: pointer; }
     font-size: 18px;
     color: var(--primary);
     margin-bottom: 6px;
+}
+
+.popupFoodsIntro {
+    font-size: 15px;
+    font-style: italic;
+    opacity: 0.8;
+    margin-bottom: 6px !important;
+}
+
+.popupFoodChips {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
+    position: relative;
+    left: 5%;
+    width: 90%;
+    margin: 0 0 6px;
+}
+
+.popupFoodChip {
+    background: var(--linen);
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    padding: 6px 14px;
+    font-family: 'Source Sans Pro', sans-serif;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--ink);
+    cursor: pointer;
+}
+
+.popupFoodChip:hover {
+    background: var(--sage);
+    color: white;
+}
+
+.popupFoodChip.excluded {
+    background: transparent;
+    text-decoration: line-through;
+    opacity: 0.5;
+}
+
+.popupFoodChip.excluded:hover {
+    background: var(--border);
+    color: var(--ink);
+    opacity: 0.8;
+}
+
+.popupTraitHeadingRow {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    position: relative;
+    left: 5%;
+    width: 90%;
+}
+
+.popupTraitHeadingRow .popupTraitHeading {
+    position: static;
+    width: auto;
+    left: auto;
+    margin-bottom: 0;
+    text-align: left;
+}
+
+.popupTraitRemove {
+    flex: 0 0 auto;
+    background: var(--paper);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 4px 12px;
+    font-family: 'Source Sans Pro', sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--clay-dark);
+    cursor: pointer;
+}
+
+.popupTraitRemove:hover {
+    background: var(--clay);
+    color: white;
+    border-color: var(--clay);
 }
 
 .analysisPopup .show {


### PR DESCRIPTION
## Summary
- Fix "Show Anlysis" → "Show Analysis" button typo.
- Chosen foods are now individual removable chips (× per food) instead of a plain comma-separated line, wired directly to the food's checkbox.
- Group the 18 food categories into five labeled clusters (Produce; Grains, Legumes & Nuts; Animal-Based; Flavor & Extras; Processed & Beverages) via a new `CATEGORY_GROUPS` config in `foods-data.js`, mirroring the existing `FILTER_SECTIONS` pattern. Any uncategorized id still renders, under a trailing "Other" section.
- Rework the analysis popup into a live, self-contained view:
  - Lists every selected food as a chip; clicking one excludes it from the popup's analysis only (struck through, click again to bring it back) — it stays listed and never touches the real selection.
  - Each shown trait gets an "Exclude" button that checks the matching filter checkbox and recomputes live, in place, without closing the popup.
  - "Print analysis" now prints the foods/traits actually shown in the live popup view instead of the full original selection.

## Test plan
- [x] Verified category grouping renders all 18 categories under the right headers via Playwright
- [x] Verified removing a chosen-food chip unchecks it and updates the summary
- [x] Verified excluding a trait in the popup checks the real filter checkbox, updates the main summary, and reveals the next-ranked trait live
- [x] Verified excluding a food in the popup keeps it listed (struck through) while removing it from the live analysis, and leaves the main selection untouched
- [x] Found and fixed a hover-state bug where an excluded food chip's text went invisible (white text on transparent background)
- [x] Verified "Print analysis" reflects the live popup state (active foods/traits), not the original full selection
- [x] Checked layout on desktop and a 412px mobile viewport


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL55zr9aoZdKaqszoMXLFd)_