### PR TITLE
Explicit close buttons for the analysis popup

### DIFF
--- a/app.html
+++ b/app.html
@@ -126,11 +126,12 @@
 
         <div class="analysisPopup">
             <div class="popupContainer" id="popupContainer">
+                <button class="popupClose noPrint" id="popupCloseBtn" aria-label="Close analysis">&times;</button>
                 <div id="popupTextContainer">
                     <!-- analysis paragraphs are added by script.js -->
                 </div>
                 <button class="button2 noPrint" id="printAnalysisButton">Print analysis</button>
-                <p class="noPrint"><em>Click on this popup to close it</em></p>
+                <button class="button2 noPrint" id="popupCloseBottomBtn">Close</button>
             </div>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -508,17 +508,24 @@
   }
 
   showAnalysisButton.addEventListener("click", function () {
-    const opening = !popupContainer.classList.contains("show");
-    if (opening) {
-      popupAllFoods = getSelectedFoods();
-      popupExcludedFoods = new Set();
-      renderPopupAnalysis();
-    }
-    popupContainer.classList.toggle("show");
+    popupAllFoods = getSelectedFoods();
+    popupExcludedFoods = new Set();
+    renderPopupAnalysis();
+    popupContainer.classList.add("show");
   });
 
-  popupContainer.addEventListener("click", function () {
-    popupContainer.classList.toggle("show");
+  function closePopup() {
+    popupContainer.classList.remove("show");
+  }
+
+  document.getElementById("popupCloseBtn").addEventListener("click", function (e) {
+    e.stopPropagation();
+    closePopup();
+  });
+
+  document.getElementById("popupCloseBottomBtn").addEventListener("click", function (e) {
+    e.stopPropagation();
+    closePopup();
   });
 
   document.getElementById("printAnalysisButton").addEventListener("click", function (e) {

--- a/styles.css
+++ b/styles.css
@@ -586,7 +586,27 @@ input[type="checkbox"]:hover { cursor: pointer; }
     overflow-y: auto;
 }
 
-.popupContainer:hover { cursor: pointer; }
+.popupClose {
+    position: fixed;
+    top: calc(5% + 10px);
+    right: 6%;
+    background: var(--paper);
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    width: 34px;
+    height: 34px;
+    font-size: 20px;
+    line-height: 1;
+    color: var(--primary);
+    cursor: pointer;
+    z-index: 2;
+}
+
+.popupClose:hover {
+    background: var(--clay);
+    color: white;
+    border-color: var(--clay);
+}
 
 .popupContainer p {
     position: relative;
@@ -896,6 +916,7 @@ footer p { color: var(--linen); }
 
     .popupContainer { padding: 60px 0; top: 0; left: 5%; max-height: 90vh; }
     .popupContainer p { font-size: max(3.5vw, 18px); left: 3%; width: 94%; }
+    .popupClose { top: 10px; }
 
 
 


### PR DESCRIPTION
## Summary
- Removed the "click anywhere on the popup closes it" behavior, which made accidental closes easy while reading or interacting with the analysis.
- Added a round × button pinned to the top-right corner of the popup.
- Added a "Close" button next to "Print analysis" at the bottom, replacing the old "Click on this popup to close it" hint text.

## Test plan
- [x] Verified clicking plain body text inside the popup no longer closes it
- [x] Verified both the top-right × and the bottom "Close" button close the popup
- [x] Checked placement on desktop and confirmed the mobile media query keeps the × aligned with the popup's mobile top offset


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL55zr9aoZdKaqszoMXLFd)_