### PR TITLE
Fix analysis popup hidden behind mobile header

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -579,7 +579,7 @@ input[type="checkbox"]:hover { cursor: pointer; }
     box-shadow: 0 20px 50px rgba(21, 65, 76, 0.25);
     padding: 50px 0;
     position: fixed;
-    z-index: 1;
+    z-index: 960;
     top: 5%;
     left: 5%;
     max-height: 85vh;


### PR DESCRIPTION
Root cause: `.popupContainer` had `z-index: 1`, far below the fixed header's `z-index: 500`. On mobile, the popup sits at `top: 0` (flush with the header), so the header rendered on top and hid the popup's top edge and close button. Raised the popup to `z-index: 960` — above both the header (500) and the nav drawer (950) — so it's always the topmost layer while open.

## Test plan
- [x] Verified on a 412px mobile viewport that the × button is now the topmost element at its location and closes the popup on click
- [x] Verified desktop layout is unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL55zr9aoZdKaqszoMXLFd)_