### PR TITLE
Larger mobile body text and headings on landing page

### DIFF
--- a/about.html
+++ b/about.html
@@ -110,7 +110,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.2 — updated July 2026</p>
+        <p>Pre-beta v0.3 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/app.html
+++ b/app.html
@@ -157,7 +157,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.2 — updated July 2026</p>
+    <p>Pre-beta v0.3 — updated 16 July 2026</p>
 </footer>
 
 <script src="foods-data.js"></script>

--- a/articles.html
+++ b/articles.html
@@ -69,7 +69,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.2 — updated July 2026</p>
+    <p>Pre-beta v0.3 — updated 16 July 2026</p>
 </footer>
 
 <script src="articles-data.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -55,7 +55,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.2 — updated July 2026</p>
+        <p>Pre-beta v0.3 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/index.html
+++ b/index.html
@@ -43,19 +43,17 @@
 
     <section class="hero">
         <h2>Some foods don't just taste different. They react differently in you.</h2>
-        <p>This is a triage tool for exploring possible GI reactions to foods — built for dietitians and other
-            health care professionals, and open for anyone curious about the patterns behind their own symptoms.</p>
-        <p>Pick a handful of foods someone reacts to. The tool looks for what they have in common — a shared
-            FODMAP subtype, a histamine load, a hidden allergen — the kind of overlap that's easy to miss meal
-            by meal, but obvious once it's laid out.</p>
+        <p>A triage tool for exploring possible GI reactions to foods — built for dietitians and other health
+            professionals, and open to anyone curious about their own symptoms.</p>
+        <p>Pick a handful of foods someone reacts to, and the tool finds what they share — a FODMAP subtype,
+            a histamine load, a hidden allergen — patterns easy to miss meal by meal, but obvious once laid out.</p>
         <a class="button2 heroButton" href="app.html">Launch the app →</a>
     </section>
 
     <section class="demo">
         <h2>Try it — pick a few foods</h2>
-        <p>Six common foods that carry FODMAPs or histamine — pick at least two and see their top shared traits,
-            ranked by how many of your foods carry each one. The full app tracks over 30 traits across 250+
-            foods.</p>
+        <p>Six common foods with FODMAPs or histamine — pick at least two to see their top shared traits.
+            The full app tracks 30+ traits across 250+ foods.</p>
 
         <div id="demoFoods" class="demoFoods"></div>
 
@@ -64,8 +62,8 @@
             <ul id="demoTraitList" class="demoTraitList"></ul>
         </div>
 
-        <p class="demoDisclaimer">This mini-demo is for illustration only, not medical advice — same as the full
-            app. <a href="app.html">Read the full disclaimer</a> when you launch it.</p>
+        <p class="demoDisclaimer">This mini-demo is for illustration only, not medical advice.
+            <a href="app.html">Read the full disclaimer</a> in the app.</p>
     </section>
 
     <section class="linksOut">
@@ -88,7 +86,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.2 — updated July 2026</p>
+        <p>Pre-beta v0.3 — updated 16 July 2026</p>
     </footer>
 
     <script src="foods-data.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -954,7 +954,7 @@ footer p { color: var(--linen); }
 }
 
 .hero h2 {
-    font-size: 32px;
+    font-size: 38px;
     line-height: 1.3;
     color: var(--primary);
     margin-bottom: 20px;
@@ -979,6 +979,10 @@ footer p { color: var(--linen); }
     border: 1px solid var(--border);
     border-radius: 16px;
     text-align: center;
+}
+
+.demo h2 {
+    font-size: 28px;
 }
 
 .demoFoods {
@@ -1045,6 +1049,7 @@ footer p { color: var(--linen); }
 .linkCard h3 {
     color: var(--primary);
     margin-top: 0;
+    font-size: 22px;
 }
 
 .linkCard a {
@@ -1058,7 +1063,12 @@ footer p { color: var(--linen); }
 }
 
 @media (max-width: 700px) {
-    .hero h2 { font-size: 24px; }
+    /* Front page body text: fixed-minimum size instead of pure vw so it stays
+       readable on narrow phones (the global "p" rule alone can drop below 16px). */
+    .hero h2 { font-size: 28px; }
+    .demo h2 { font-size: 22px; }
+    .hero p, .demo p, .demoDisclaimer, .linkCard p { font-size: clamp(16px, 4.5vw, 18px); }
+    .linkCard h3 { font-size: 20px; }
     .demo { margin: 30px 15px; padding: 20px; }
     .linksOut { margin: 30px 15px; }
 }


### PR DESCRIPTION
## Summary
- Front-page body text was shrinking to ~13px on narrow phones via pure `vw` sizing; switched to a clamped minimum so it stays readable.
- Landing-page headings (hero, demo, link cards) enlarged ~15-20%.
- Trimmed front-page copy to fit the larger text.
- Bumped version to v0.3 across all pages.

## Test plan
- [x] Reviewed CSS changes for the mobile breakpoint (`max-width: 700px`)
- [ ] Visual check on a real mobile viewport


---
_Generated by [Claude Code](https://claude.ai/code/session_011RFTNpYCoGNczVyDjYX34K)_