### PR TITLE
Extend text enlargement to articles and about pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -110,7 +110,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.3 — updated 16 July 2026</p>
+        <p>Pre-beta v0.4 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/app.html
+++ b/app.html
@@ -157,7 +157,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.3 — updated 16 July 2026</p>
+    <p>Pre-beta v0.4 — updated 16 July 2026</p>
 </footer>
 
 <script src="foods-data.js"></script>

--- a/articles.html
+++ b/articles.html
@@ -69,7 +69,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.3 — updated 16 July 2026</p>
+    <p>Pre-beta v0.4 — updated 16 July 2026</p>
 </footer>
 
 <script src="articles-data.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -55,7 +55,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.3 — updated 16 July 2026</p>
+        <p>Pre-beta v0.4 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.3 — updated 16 July 2026</p>
+        <p>Pre-beta v0.4 — updated 16 July 2026</p>
     </footer>
 
     <script src="foods-data.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -807,7 +807,7 @@ input[type="checkbox"]:hover { cursor: pointer; }
     top: 20px;
 }
 
-.articleIndex h2 { margin-top: 0; font-size: 20px; }
+.articleIndex h2 { margin-top: 0; font-size: 23px; }
 
 .articleIndex ul { list-style: none; padding: 0; margin: 0; }
 
@@ -840,9 +840,12 @@ input[type="checkbox"]:hover { cursor: pointer; }
 .articleContent h1 {
     color: var(--primary);
     font-family: 'Lora', serif;
+    font-size: clamp(30px, 4.8vw, 44px);
 }
 
-.articleContent h2 { margin-top: 30px; }
+.articleContent h2 { margin-top: 30px; font-size: 28px; }
+
+.articleContent h3 { font-size: 21px; margin-top: 20px; }
 
 .articleNote {
     background: rgba(126, 155, 122, 0.14);
@@ -922,6 +925,10 @@ footer p { color: var(--linen); }
 
     .articleLayout { flex-direction: column; margin: 6vw; box-sizing: border-box; }
     .articleIndex { position: static; flex: none; width: 100%; box-sizing: border-box; }
+
+    /* Article/about body text: fixed-minimum size so it doesn't shrink
+       below ~16px on narrow phones like the old pure-vw sizing did. */
+    .articleContent p, .neck p, .articleContent li, .articleNote { font-size: clamp(16px, 4.5vw, 18px); }
 }
 
 @media (min-width: 3800px) {


### PR DESCRIPTION
## Summary
- Article/about body text no longer shrinks below ~16px on mobile (same fix as the landing page, applied to `.articleContent`/`.neck` paragraphs).
- Article title, section headings (h2/h3), and sidebar nav heading enlarged ~15-20%.
- Bumped version to v0.4.

## Test plan
- [x] Reviewed CSS specificity so fixed heading sizes win over the generic mobile `h2` rule
- [ ] Visual check on articles.html and about.html on a real mobile viewport


---
_Generated by [Claude Code](https://claude.ai/code/session_011RFTNpYCoGNczVyDjYX34K)_