### PR TITLE
Tune article typography and drop abbreviation parens from titles

### DIFF
--- a/articles-data.js
+++ b/articles-data.js
@@ -402,12 +402,12 @@ const ARTICLES = {
   },
 
   cross_reactive: {
-    title: "Pollen-Food Cross-Reactivity (OAS)",
+    title: "Pollen-Food Cross-Reactivity",
     sections: [
       {
         heading: "What is OAS?",
         blocks: [
-          { type: "p", text: "Oral allergy syndrome occurs when foods contain proteins structurally similar to pollen allergens, causing mild tingling or itching in the mouth in people already allergic to that pollen. Most of these proteins are heat-labile, so symptoms often resolve once the food is cooked — but some (like certain lipid transfer proteins) are heat-stable and can still trigger reactions, occasionally more severe ones, even when cooked." }
+          { type: "p", text: "Oral allergy syndrome (OAS) occurs when foods contain proteins structurally similar to pollen allergens, causing mild tingling or itching in the mouth in people already allergic to that pollen. Most of these proteins are heat-labile, so symptoms often resolve once the food is cooked — but some (like certain lipid transfer proteins) are heat-stable and can still trigger reactions, occasionally more severe ones, even when cooked." }
         ]
       },
       {
@@ -470,12 +470,12 @@ const ARTICLES = {
   },
 
   fructose: {
-    title: "Fructose (Excess)",
+    title: "Fructose",
     sections: [
       {
         heading: null,
         blocks: [
-          { type: "p", text: "Excess free fructose relative to glucose overwhelms small-intestine absorption, drawing water into the bowel. Found in honey, apples, mangoes, and high-fructose corn syrup." }
+          { type: "p", text: "This article is about excess fructose specifically — more free fructose than glucose in a meal, which overwhelms small-intestine absorption and draws water into the bowel. Found in honey, apples, mangoes, and high-fructose corn syrup." }
         ]
       },
       {
@@ -490,12 +490,12 @@ const ARTICLES = {
   },
 
   polyols: {
-    title: "Polyols (Sugar Alcohols)",
+    title: "Polyols",
     sections: [
       {
         heading: null,
         blocks: [
-          { type: "p", text: "Sorbitol and mannitol are poorly absorbed, pulling water into the bowel osmotically and getting fermented by colon bacteria, producing gas. Common in stone fruits, mushrooms, and sugar-free sweeteners (chewing gum, \"diet\" products)." },
+          { type: "p", text: "Polyols — sugar alcohols such as sorbitol and mannitol — are poorly absorbed, pulling water into the bowel osmotically and getting fermented by colon bacteria, producing gas. Common in stone fruits, mushrooms, and sugar-free sweeteners (chewing gum, \"diet\" products)." },
           { type: "p", text: "This osmotic effect is dose-dependent and well known enough that many sugar-free products carry a laxative-effect warning label — worth checking if bloating or diarrhea follows sugar-free snacks or gum." }
         ]
       },
@@ -528,12 +528,12 @@ const ARTICLES = {
   },
 
   galactans: {
-    title: "Galacto-oligosaccharides (GOS)",
+    title: "Galacto-oligosaccharides",
     sections: [
       {
         heading: null,
         blocks: [
-          { type: "p", text: "Short galactose chains the small intestine can't break down, fermented in the colon. Main sources: legumes and some nuts." },
+          { type: "p", text: "Galacto-oligosaccharides (GOS) are short galactose chains the small intestine can't break down, fermented in the colon. Main sources: legumes and some nuts." },
           { type: "p", text: "Symptoms are typical FODMAP fermentation symptoms — gas and bloating, dose-dependent. Soaking or sprouting legumes before cooking reduces their GOS content and is a common practical tip for better tolerance." }
         ]
       },

--- a/styles.css
+++ b/styles.css
@@ -817,6 +817,7 @@ input[type="checkbox"]:hover { cursor: pointer; }
     text-decoration: none;
     color: var(--primary);
     font-weight: 600;
+    font-size: 19px;
     display: block;
     padding: 6px 10px;
     border-radius: 8px;
@@ -843,7 +844,7 @@ input[type="checkbox"]:hover { cursor: pointer; }
     font-size: clamp(30px, 4.8vw, 44px);
 }
 
-.articleContent h2 { margin-top: 30px; font-size: 28px; }
+.articleContent h2 { margin-top: 30px; font-size: 25px; }
 
 .articleContent h3 { font-size: 21px; margin-top: 20px; }
 
@@ -928,7 +929,7 @@ footer p { color: var(--linen); }
 
     /* Article/about body text: fixed-minimum size so it doesn't shrink
        below ~16px on narrow phones like the old pure-vw sizing did. */
-    .articleContent p, .neck p, .articleContent li, .articleNote { font-size: clamp(16px, 4.5vw, 18px); }
+    .articleContent p, .neck p, .articleContent li, .articleNote { font-size: clamp(18px, 4.5vw, 19px); }
 }
 
 @media (min-width: 3800px) {
@@ -1074,7 +1075,7 @@ footer p { color: var(--linen); }
        readable on narrow phones (the global "p" rule alone can drop below 16px). */
     .hero h2 { font-size: 28px; }
     .demo h2 { font-size: 22px; }
-    .hero p, .demo p, .demoDisclaimer, .linkCard p { font-size: clamp(16px, 4.5vw, 18px); }
+    .hero p, .demo p, .demoDisclaimer, .linkCard p { font-size: clamp(18px, 4.5vw, 19px); }
     .linkCard h3 { font-size: 20px; }
     .demo { margin: 30px 15px; padding: 20px; }
     .linksOut { margin: 30px 15px; }


### PR DESCRIPTION
## Summary
- `.articleContent h2` (section headings) reduced ~10% (28px → 25px).
- Article-menu links (`.articleIndex a`) enlarged ~20% (16px → 19px).
- Mobile body-text floor raised from 16px to 18px on the landing/article/about pages.
- Removed the `(OAS)`, `(GOS)`, `(Excess)`, `(Sugar Alcohols)` suffixes from article titles/links; the abbreviations now appear in the article body text instead.

## Test plan
- [ ] Visual check on articles.html and about.html on mobile


---
_Generated by [Claude Code](https://claude.ai/code/session_011RFTNpYCoGNczVyDjYX34K)_