### PR TITLE
Reorder article menu to mirror the filter list

### DIFF
--- a/about.html
+++ b/about.html
@@ -110,7 +110,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.4 — updated 16 July 2026</p>
+        <p>Pre-beta v0.5 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/app.html
+++ b/app.html
@@ -157,7 +157,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.4 — updated 16 July 2026</p>
+    <p>Pre-beta v0.5 — updated 16 July 2026</p>
 </footer>
 
 <script src="foods-data.js"></script>

--- a/articles-data.js
+++ b/articles-data.js
@@ -27,7 +27,12 @@
    in foods-data.js, set `articleId: "myTopic"` on that trait.
 
    It will automatically show up in the article index on articles.html in
-   whatever order it's defined here.
+   whatever order it's defined here. That order is deliberately kept in
+   step with the filter list (FILTER_SECTIONS in foods-data.js): the
+   macronutrient overview first, then GI Irritants, FODMAPs (broad +
+   subtypes), Other Digestive Factors, Allergens, then Cross-Reactivity
+   & Delayed Allergy — matching how a reader encounters the same topics
+   on the checklist.
    ========================================================================= */
 
 const ARTICLES = {
@@ -63,96 +68,6 @@ const ARTICLES = {
         heading: null,
         blocks: [
           { type: "note", text: "See the individual carbohydrate, protein, fat, and fiber articles for symptom-specific detail." }
-        ]
-      }
-    ]
-  },
-
-  fiber: {
-    title: "Fiber",
-    sections: [
-      {
-        heading: "What is fiber?",
-        blocks: [
-          { type: "p", text: "Fiber is the part of plant foods the body can't fully digest. It passes through the digestive system largely intact, which is exactly what makes it so useful — and, for some people, occasionally uncomfortable." }
-        ]
-      },
-      {
-        heading: "Health benefits",
-        blocks: [
-          { type: "p", text: "Fiber supports gut health and the gut microbiome, heart health, blood sugar regulation, weight control, and helps move waste (and the toxins bound to it) through the digestive tract." }
-        ]
-      },
-      {
-        heading: "Food sources",
-        blocks: [
-          { type: "p", text: "Fiber is present in plant foods: vegetables, fruits, whole grains, legumes, nuts, and seeds. Processed foods usually contain less fiber than their whole-food counterparts, though some are fortified with added fiber. Foods particularly high in fiber include flax seeds, chia seeds, wheat and oat bran, whole grain pasta, bread and rice, and beans and peas." }
-        ]
-      },
-      {
-        heading: "What problems can fiber cause?",
-        blocks: [
-          { type: "p", text: "Overconsumption from supplements carries real risks for anyone: in rare cases, ileus (a bowel blockage), constipation (especially combined with low water intake), gas, and bloating. Overconsumption from whole foods is gentler, but can still reduce appetite and lead to unintended weight loss if taken to an extreme." }
-        ]
-      },
-      {
-        heading: "Who is more sensitive?",
-        blocks: [
-          { type: "p", text: "Fiber can cause more pronounced symptoms in people with certain sensitivities — IBS, reflux, slowed gastric emptying, short bowel syndrome, or small intestinal bacterial overgrowth (SIBO), among others." }
-        ]
-      },
-      {
-        heading: null,
-        blocks: [
-          { type: "note", text: "Don't stick to a low-fiber, low-variety diet for more than a couple of weeks unless it's clearly necessary." }
-        ]
-      }
-    ]
-  },
-
-  fodmaps: {
-    title: "FODMAPs",
-    sections: [
-      {
-        heading: "What are FODMAPs?",
-        blocks: [
-          { type: "p", text: "FODMAP stands for Fermentable Oligosaccharides, Disaccharides, Monosaccharides, and Polyols. These are short-chain carbohydrates that aren't fully absorbed in the small intestine. Instead, they travel on to the colon, where gut bacteria ferment them." },
-          { type: "list", items: [
-            "**Oligosaccharides**: fructans and galacto-oligosaccharides, found in wheat, onion, garlic, and many legumes",
-            "**Disaccharides**: mainly lactose, found in dairy",
-            "**Monosaccharides**: excess fructose, found in some fruits and honey",
-            "**Polyols**: sugar alcohols like sorbitol and mannitol, found in some fruits and sugar-free sweeteners"
-          ]}
-        ]
-      },
-      {
-        heading: "Why they cause symptoms",
-        blocks: [
-          { type: "p", text: "Because they aren't well absorbed, FODMAPs draw extra water into the bowel and are fermented by gut bacteria, producing gas. For most people this fermentation effect is mild and tends to improve over time as the gut microbiome adapts, even without reducing intake." }
-        ]
-      },
-      {
-        heading: "Who is more sensitive?",
-        blocks: [
-          { type: "p", text: "For sensitive individuals — such as people with Irritable Bowel Syndrome (IBS) — moderate symptoms can occur even at a relatively low intake, and the microbiome adapts more slowly. At a high daily intake, symptoms can become severe, causing acute diarrhea and pain." }
-        ]
-      },
-      {
-        heading: "Common high-FODMAP foods",
-        blocks: [
-          { type: "p", text: "On this site's food checklist, foods flagged with the FODMAPs trait include onions, garlic, wheat, rye, barley, many legumes (chickpeas, lentils, black beans), apples, and several nuts (almonds, cashews, hazelnuts, peanuts)." }
-        ]
-      },
-      {
-        heading: "The low-FODMAP approach",
-        blocks: [
-          { type: "p", text: "A structured elimination-and-reintroduction approach (most known from Monash University's research) is commonly used to identify individual triggers. It's meant to be short-term and systematic rather than an indefinite restriction." }
-        ]
-      },
-      {
-        heading: null,
-        blocks: [
-          { type: "note", text: "Best done with guidance from a dietitian or other healthcare professional, rather than as a self-directed long-term diet." }
         ]
       }
     ]
@@ -299,120 +214,49 @@ const ARTICLES = {
     ]
   },
 
-  allergen: {
-    title: "Allergens",
+  fodmaps: {
+    title: "FODMAPs",
     sections: [
       {
-        heading: "The \"Big 9\"",
+        heading: "What are FODMAPs?",
         blocks: [
-          { type: "p", text: "Milk, egg, wheat, fish, shellfish, peanut, tree nut, soy, and sesame cause the large majority of true, IgE-mediated food allergies — distinct from dose-dependent intolerances tracked elsewhere on this site." }
-        ]
-      },
-      {
-        heading: "Key distinctions",
-        blocks: [
+          { type: "p", text: "FODMAP stands for Fermentable Oligosaccharides, Disaccharides, Monosaccharides, and Polyols. These are short-chain carbohydrates that aren't fully absorbed in the small intestine. Instead, they travel on to the colon, where gut bacteria ferment them." },
           { type: "list", items: [
-            "Milk allergy (casein/whey) is not the same as lactose intolerance (an enzyme issue, not immune).",
-            "Egg allergy is mainly driven by egg-white proteins; the yolk is less allergenic but not necessarily safe.",
-            "Wheat allergy, celiac disease, and non-celiac gluten sensitivity are three distinct conditions.",
-            "Fish (parvalbumin) and shellfish (tropomyosin) are different allergens — one doesn't predict the other.",
-            "Peanut is a legume; peanut allergy doesn't reliably predict tree nut allergy.",
-            "Sesame is a more recently recognized Big 9 allergen and can cause severe reactions."
+            "**Oligosaccharides**: fructans and galacto-oligosaccharides, found in wheat, onion, garlic, and many legumes",
+            "**Disaccharides**: mainly lactose, found in dairy",
+            "**Monosaccharides**: excess fructose, found in some fruits and honey",
+            "**Polyols**: sugar alcohols like sorbitol and mannitol, found in some fruits and sugar-free sweeteners"
           ]}
         ]
       },
       {
-        heading: "Sensitization and reaction severity",
+        heading: "Why they cause symptoms",
         blocks: [
-          { type: "p", text: "The first exposure to an allergen often causes no reaction — it primes the immune system to produce antibodies. Later exposures can trigger much stronger reactions as antibody levels rise, which is why an allergy can appear \"suddenly\" even to a food eaten safely before." }
+          { type: "p", text: "Because they aren't well absorbed, FODMAPs draw extra water into the bowel and are fermented by gut bacteria, producing gas. For most people this fermentation effect is mild and tends to improve over time as the gut microbiome adapts, even without reducing intake." }
         ]
       },
       {
-        heading: "Tolerance",
+        heading: "Who is more sensitive?",
         blocks: [
-          { type: "p", text: "Tolerance means the immune system learns to accept a food antigen without reacting — it's the default state for most food proteins in most people. Many childhood allergies (milk, egg, wheat, soy) are outgrown as tolerance develops with age and continued exposure; others (peanut, tree nut, shellfish, fish) are more likely to persist for life." },
-          { type: "p", text: "Oral immunotherapy is an emerging approach that tries to build tolerance deliberately under medical supervision — not something to attempt unsupervised." }
+          { type: "p", text: "For sensitive individuals — such as people with Irritable Bowel Syndrome (IBS) — moderate symptoms can occur even at a relatively low intake, and the microbiome adapts more slowly. At a high daily intake, symptoms can become severe, causing acute diarrhea and pain." }
+        ]
+      },
+      {
+        heading: "Common high-FODMAP foods",
+        blocks: [
+          { type: "p", text: "On this site's food checklist, foods flagged with the FODMAPs trait include onions, garlic, wheat, rye, barley, many legumes (chickpeas, lentils, black beans), apples, and several nuts (almonds, cashews, hazelnuts, peanuts)." }
+        ]
+      },
+      {
+        heading: "The low-FODMAP approach",
+        blocks: [
+          { type: "p", text: "A structured elimination-and-reintroduction approach (most known from Monash University's research) is commonly used to identify individual triggers. It's meant to be short-term and systematic rather than an indefinite restriction." }
         ]
       },
       {
         heading: null,
         blocks: [
-          { type: "note", text: "Long-term unnecessary avoidance of a food can reduce tolerance over time, making a reaction more likely if the food is reintroduced later — this applies to true allergies, but similar patterns are seen with IBS and lactose intolerance too, even though the underlying mechanisms differ. Reintroduction is best guided by a professional rather than done alone after a long avoidance period." },
-          { type: "note", text: "If a true allergy is suspected, refer for formal allergy testing rather than relying on this tool." }
-        ]
-      }
-    ]
-  },
-
-  cross_reactive: {
-    title: "Pollen-Food Cross-Reactivity",
-    sections: [
-      {
-        heading: "What is OAS?",
-        blocks: [
-          { type: "p", text: "Oral allergy syndrome (OAS) occurs when foods contain proteins structurally similar to pollen allergens, causing mild tingling or itching in the mouth in people already allergic to that pollen. Most of these proteins are heat-labile, so symptoms often resolve once the food is cooked — but some (like certain lipid transfer proteins) are heat-stable and can still trigger reactions, occasionally more severe ones, even when cooked." }
-        ]
-      },
-      {
-        heading: "The three pollen groups",
-        blocks: [
-          { type: "list", items: [
-            "**Birch (PR-10 protein family):** apples, stone fruits, carrots, celery/celeriac, hazelnuts, soy",
-            "**Grass:** melon, watermelon, tomato, orange, peanut, potato",
-            "**Latex (chitinases):** banana, avocado, kiwi, papaya"
-          ]}
-        ]
-      },
-      {
-        heading: "Diagnosis",
-        blocks: [
-          { type: "p", text: "OAS is typically diagnosed based on the pattern of symptoms (reaction limited to the mouth/throat, tied to specific fresh foods) plus a known pollen allergy, sometimes confirmed with skin prick testing against fresh food extracts rather than standard commercial extracts, which can miss these heat-labile proteins." }
-        ]
-      },
-      {
-        heading: null,
-        blocks: [
-          { type: "note", text: "Reactions are usually mild and confined to the mouth and throat, but heat-stable proteins can occasionally cause more systemic symptoms — anyone with severe or spreading reactions should be assessed by an allergist rather than relying on food avoidance alone." }
-        ]
-      }
-    ]
-  },
-
-  lactose: {
-    title: "Lactose",
-    sections: [
-      {
-        heading: "What is lactose intolerance?",
-        blocks: [
-          { type: "p", text: "Lactose is a sugar found in milk, broken down by the enzyme lactase. When lactase activity is too low, undigested lactose draws water into the bowel and ferments in the colon, causing gas, bloating, cramping, and diarrhea." }
-        ]
-      },
-      {
-        heading: "Types",
-        blocks: [
-          { type: "list", items: [
-            "**Primary:** the most common form — lactase production naturally declines after childhood in most of the world's population",
-            "**Secondary (temporary):** caused by damage to the gut lining from another condition, and resolves once that condition is treated"
-          ]}
-        ]
-      },
-      {
-        heading: null,
-        blocks: [
-          { type: "note", text: "Untreated coeliac disease often causes temporary secondary lactose intolerance, since gut lining damage reduces lactase production. This is a key reason proper diagnosis matters — in children who previously tolerated lactose well, and arguably even more so in adults who have been lactose tolerant their whole life, since new-onset intolerance in adulthood is a stronger signal that something else needs investigating." }
-        ]
-      },
-      {
-        heading: "Lactose and FODMAPs/IBS",
-        blocks: [
-          { type: "p", text: "Lactose is one of the FODMAP subtypes (the \"D\" for disaccharides), so it's tested during a structured low-FODMAP elimination diet alongside fructans, GOS, and polyols. People with IBS often have some degree of lactose sensitivity even with normal lactase levels, since IBS increases general sensitivity to fermentable sugars — not just lactose specifically." },
-          { type: "note", text: "As a FODMAP subtype, lactose is mainly a problem for people with IBS, though it can also cause discomfort in other GI disorders, or in anyone if consumption is high enough." }
-        ]
-      },
-      {
-        heading: "Managing it",
-        blocks: [
-          { type: "p", text: "Tolerance is dose- and dairy-type dependent — many people can tolerate small amounts or fermented/aged dairy (yogurt, hard cheese) even if unable to tolerate a glass of milk." }
+          { type: "note", text: "Best done with guidance from a dietitian or other healthcare professional, rather than as a self-directed long-term diet." }
         ]
       }
     ]
@@ -544,71 +388,83 @@ const ARTICLES = {
     ]
   },
 
-  bile_stimulant: {
-    title: "Bile Stimulants",
+  lactose: {
+    title: "Lactose",
     sections: [
       {
-        heading: "What triggers bile release?",
+        heading: "What is lactose intolerance?",
         blocks: [
-          { type: "p", text: "Fat is the dominant dietary trigger of cholecystokinin (CCK), a hormone that signals the gallbladder to contract and release bile. Protein is a weaker, secondary trigger. Fried and smoked foods are common contributors too, both because they're typically high in fat and because the frying/smoking process itself can add further irritant compounds." }
+          { type: "p", text: "Lactose is a sugar found in milk, broken down by the enzyme lactase. When lactase activity is too low, undigested lactose draws water into the bowel and ferments in the colon, causing gas, bloating, cramping, and diarrhea." }
         ]
       },
       {
-        heading: "Clinical relevance",
+        heading: "Types",
         blocks: [
           { type: "list", items: [
-            "Egg yolk is used clinically as a standard fatty-meal challenge to test gallbladder emptying via ultrasound",
-            "Curcumin (turmeric) causes dose-dependent gallbladder contraction separately from fat content",
-            "Most relevant for people with gallstones, biliary colic, or a history of gallbladder attacks — a strong contraction can trigger pain"
+            "**Primary:** the most common form — lactase production naturally declines after childhood in most of the world's population",
+            "**Secondary (temporary):** caused by damage to the gut lining from another condition, and resolves once that condition is treated"
           ]}
-        ]
-      },
-      {
-        heading: "After gallbladder removal",
-        blocks: [
-          { type: "p", text: "After cholecystectomy, bile drips continuously into the gut instead of being released in a controlled burst with meals. Fat-rich meals can then cause bile acid diarrhea, a different mechanism from the pain caused by an intact but diseased gallbladder." }
         ]
       },
       {
         heading: null,
         blocks: [
-          { type: "note", text: "Foods are tagged here based on fat/protein content thresholds rather than a formal clinical classification — treat this as a starting point rather than a diagnostic label." }
+          { type: "note", text: "Untreated coeliac disease often causes temporary secondary lactose intolerance, since gut lining damage reduces lactase production. This is a key reason proper diagnosis matters — in children who previously tolerated lactose well, and arguably even more so in adults who have been lactose tolerant their whole life, since new-onset intolerance in adulthood is a stronger signal that something else needs investigating." }
+        ]
+      },
+      {
+        heading: "Lactose and FODMAPs/IBS",
+        blocks: [
+          { type: "p", text: "Lactose is one of the FODMAP subtypes (the \"D\" for disaccharides), so it's tested during a structured low-FODMAP elimination diet alongside fructans, GOS, and polyols. People with IBS often have some degree of lactose sensitivity even with normal lactase levels, since IBS increases general sensitivity to fermentable sugars — not just lactose specifically." },
+          { type: "note", text: "As a FODMAP subtype, lactose is mainly a problem for people with IBS, though it can also cause discomfort in other GI disorders, or in anyone if consumption is high enough." }
+        ]
+      },
+      {
+        heading: "Managing it",
+        blocks: [
+          { type: "p", text: "Tolerance is dose- and dairy-type dependent — many people can tolerate small amounts or fermented/aged dairy (yogurt, hard cheese) even if unable to tolerate a glass of milk." }
         ]
       }
     ]
   },
 
-  alpha_gal: {
-    title: "Alpha-Gal Syndrome",
+  fiber: {
+    title: "Fiber",
     sections: [
       {
-        heading: "What is alpha-gal syndrome?",
+        heading: "What is fiber?",
         blocks: [
-          { type: "p", text: "Alpha-gal syndrome (AGS) is a delayed allergic reaction to galactose-alpha-1,3-galactose, a sugar molecule found in the meat of mammals. Unlike most food allergies, it's not triggered by a protein, and the sensitization doesn't come from food at all — it starts with a tick bite." }
+          { type: "p", text: "Fiber is the part of plant foods the body can't fully digest. It passes through the digestive system largely intact, which is exactly what makes it so useful — and, for some people, occasionally uncomfortable." }
         ]
       },
       {
-        heading: "The tick-bite mechanism",
+        heading: "Health benefits",
         blocks: [
-          { type: "p", text: "Certain tick species carry alpha-gal in their saliva. A bite can sensitize the immune system to this molecule, and afterward, eating mammalian meat can trigger an allergic reaction. The Lone Star tick is the most documented cause, but other species — including some found in Scandinavia and Europe — have also been implicated." }
+          { type: "p", text: "Fiber supports gut health and the gut microbiome, heart health, blood sugar regulation, weight control, and helps move waste (and the toxins bound to it) through the digestive tract." }
         ]
       },
       {
-        heading: "Why it's easy to miss",
+        heading: "Food sources",
         blocks: [
-          { type: "p", text: "Reactions typically appear 3 to 8 hours after eating, not within minutes like most food allergies. This delay makes the food connection easy to overlook — someone might eat dinner, then wake up in the middle of the night with hives, GI symptoms, or anaphylaxis, with no obvious trigger in sight." }
+          { type: "p", text: "Fiber is present in plant foods: vegetables, fruits, whole grains, legumes, nuts, and seeds. Processed foods usually contain less fiber than their whole-food counterparts, though some are fortified with added fiber. Foods particularly high in fiber include flax seeds, chia seeds, wheat and oat bran, whole grain pasta, bread and rice, and beans and peas." }
         ]
       },
       {
-        heading: "Which foods are affected",
+        heading: "What problems can fiber cause?",
         blocks: [
-          { type: "p", text: "Beef, pork, lamb, and other mammalian meat and meat products (sausages, cured meats, minced meat) can trigger reactions. Poultry and fish are not affected, since alpha-gal is specific to mammals. Dairy is a gray area — some people with AGS react to dairy fat, but many don't; this isn't tagged in the tool, but worth asking about individually." }
+          { type: "p", text: "Overconsumption from supplements carries real risks for anyone: in rare cases, ileus (a bowel blockage), constipation (especially combined with low water intake), gas, and bloating. Overconsumption from whole foods is gentler, but can still reduce appetite and lead to unintended weight loss if taken to an extreme." }
         ]
       },
       {
-        heading: "Diagnosis",
+        heading: "Who is more sensitive?",
         blocks: [
-          { type: "p", text: "A specific alpha-gal IgE blood test can confirm the diagnosis. Given the delayed and inconsistent symptom pattern, AGS is worth considering in unexplained nighttime allergic reactions or GI symptoms, especially in people with a known tick bite history." }
+          { type: "p", text: "Fiber can cause more pronounced symptoms in people with certain sensitivities — IBS, reflux, slowed gastric emptying, short bowel syndrome, or small intestinal bacterial overgrowth (SIBO), among others." }
+        ]
+      },
+      {
+        heading: null,
+        blocks: [
+          { type: "note", text: "Don't stick to a low-fiber, low-variety diet for more than a couple of weeks unless it's clearly necessary." }
         ]
       }
     ]
@@ -660,6 +516,155 @@ const ARTICLES = {
         heading: null,
         blocks: [
           { type: "note", text: "Work with a dietitian or physician experienced in histamine intolerance before starting an elimination diet — it's easy to over-restrict and end up with unnecessary nutrient gaps." }
+        ]
+      }
+    ]
+  },
+
+  bile_stimulant: {
+    title: "Bile Stimulants",
+    sections: [
+      {
+        heading: "What triggers bile release?",
+        blocks: [
+          { type: "p", text: "Fat is the dominant dietary trigger of cholecystokinin (CCK), a hormone that signals the gallbladder to contract and release bile. Protein is a weaker, secondary trigger. Fried and smoked foods are common contributors too, both because they're typically high in fat and because the frying/smoking process itself can add further irritant compounds." }
+        ]
+      },
+      {
+        heading: "Clinical relevance",
+        blocks: [
+          { type: "list", items: [
+            "Egg yolk is used clinically as a standard fatty-meal challenge to test gallbladder emptying via ultrasound",
+            "Curcumin (turmeric) causes dose-dependent gallbladder contraction separately from fat content",
+            "Most relevant for people with gallstones, biliary colic, or a history of gallbladder attacks — a strong contraction can trigger pain"
+          ]}
+        ]
+      },
+      {
+        heading: "After gallbladder removal",
+        blocks: [
+          { type: "p", text: "After cholecystectomy, bile drips continuously into the gut instead of being released in a controlled burst with meals. Fat-rich meals can then cause bile acid diarrhea, a different mechanism from the pain caused by an intact but diseased gallbladder." }
+        ]
+      },
+      {
+        heading: null,
+        blocks: [
+          { type: "note", text: "Foods are tagged here based on fat/protein content thresholds rather than a formal clinical classification — treat this as a starting point rather than a diagnostic label." }
+        ]
+      }
+    ]
+  },
+
+  allergen: {
+    title: "Allergens",
+    sections: [
+      {
+        heading: "The \"Big 9\"",
+        blocks: [
+          { type: "p", text: "Milk, egg, wheat, fish, shellfish, peanut, tree nut, soy, and sesame cause the large majority of true, IgE-mediated food allergies — distinct from dose-dependent intolerances tracked elsewhere on this site." }
+        ]
+      },
+      {
+        heading: "Key distinctions",
+        blocks: [
+          { type: "list", items: [
+            "Milk allergy (casein/whey) is not the same as lactose intolerance (an enzyme issue, not immune).",
+            "Egg allergy is mainly driven by egg-white proteins; the yolk is less allergenic but not necessarily safe.",
+            "Wheat allergy, celiac disease, and non-celiac gluten sensitivity are three distinct conditions.",
+            "Fish (parvalbumin) and shellfish (tropomyosin) are different allergens — one doesn't predict the other.",
+            "Peanut is a legume; peanut allergy doesn't reliably predict tree nut allergy.",
+            "Sesame is a more recently recognized Big 9 allergen and can cause severe reactions."
+          ]}
+        ]
+      },
+      {
+        heading: "Sensitization and reaction severity",
+        blocks: [
+          { type: "p", text: "The first exposure to an allergen often causes no reaction — it primes the immune system to produce antibodies. Later exposures can trigger much stronger reactions as antibody levels rise, which is why an allergy can appear \"suddenly\" even to a food eaten safely before." }
+        ]
+      },
+      {
+        heading: "Tolerance",
+        blocks: [
+          { type: "p", text: "Tolerance means the immune system learns to accept a food antigen without reacting — it's the default state for most food proteins in most people. Many childhood allergies (milk, egg, wheat, soy) are outgrown as tolerance develops with age and continued exposure; others (peanut, tree nut, shellfish, fish) are more likely to persist for life." },
+          { type: "p", text: "Oral immunotherapy is an emerging approach that tries to build tolerance deliberately under medical supervision — not something to attempt unsupervised." }
+        ]
+      },
+      {
+        heading: null,
+        blocks: [
+          { type: "note", text: "Long-term unnecessary avoidance of a food can reduce tolerance over time, making a reaction more likely if the food is reintroduced later — this applies to true allergies, but similar patterns are seen with IBS and lactose intolerance too, even though the underlying mechanisms differ. Reintroduction is best guided by a professional rather than done alone after a long avoidance period." },
+          { type: "note", text: "If a true allergy is suspected, refer for formal allergy testing rather than relying on this tool." }
+        ]
+      }
+    ]
+  },
+
+  cross_reactive: {
+    title: "Pollen-Food Cross-Reactivity",
+    sections: [
+      {
+        heading: "What is OAS?",
+        blocks: [
+          { type: "p", text: "Oral allergy syndrome (OAS) occurs when foods contain proteins structurally similar to pollen allergens, causing mild tingling or itching in the mouth in people already allergic to that pollen. Most of these proteins are heat-labile, so symptoms often resolve once the food is cooked — but some (like certain lipid transfer proteins) are heat-stable and can still trigger reactions, occasionally more severe ones, even when cooked." }
+        ]
+      },
+      {
+        heading: "The three pollen groups",
+        blocks: [
+          { type: "list", items: [
+            "**Birch (PR-10 protein family):** apples, stone fruits, carrots, celery/celeriac, hazelnuts, soy",
+            "**Grass:** melon, watermelon, tomato, orange, peanut, potato",
+            "**Latex (chitinases):** banana, avocado, kiwi, papaya"
+          ]}
+        ]
+      },
+      {
+        heading: "Diagnosis",
+        blocks: [
+          { type: "p", text: "OAS is typically diagnosed based on the pattern of symptoms (reaction limited to the mouth/throat, tied to specific fresh foods) plus a known pollen allergy, sometimes confirmed with skin prick testing against fresh food extracts rather than standard commercial extracts, which can miss these heat-labile proteins." }
+        ]
+      },
+      {
+        heading: null,
+        blocks: [
+          { type: "note", text: "Reactions are usually mild and confined to the mouth and throat, but heat-stable proteins can occasionally cause more systemic symptoms — anyone with severe or spreading reactions should be assessed by an allergist rather than relying on food avoidance alone." }
+        ]
+      }
+    ]
+  },
+
+  alpha_gal: {
+    title: "Alpha-Gal Syndrome",
+    sections: [
+      {
+        heading: "What is alpha-gal syndrome?",
+        blocks: [
+          { type: "p", text: "Alpha-gal syndrome (AGS) is a delayed allergic reaction to galactose-alpha-1,3-galactose, a sugar molecule found in the meat of mammals. Unlike most food allergies, it's not triggered by a protein, and the sensitization doesn't come from food at all — it starts with a tick bite." }
+        ]
+      },
+      {
+        heading: "The tick-bite mechanism",
+        blocks: [
+          { type: "p", text: "Certain tick species carry alpha-gal in their saliva. A bite can sensitize the immune system to this molecule, and afterward, eating mammalian meat can trigger an allergic reaction. The Lone Star tick is the most documented cause, but other species — including some found in Scandinavia and Europe — have also been implicated." }
+        ]
+      },
+      {
+        heading: "Why it's easy to miss",
+        blocks: [
+          { type: "p", text: "Reactions typically appear 3 to 8 hours after eating, not within minutes like most food allergies. This delay makes the food connection easy to overlook — someone might eat dinner, then wake up in the middle of the night with hives, GI symptoms, or anaphylaxis, with no obvious trigger in sight." }
+        ]
+      },
+      {
+        heading: "Which foods are affected",
+        blocks: [
+          { type: "p", text: "Beef, pork, lamb, and other mammalian meat and meat products (sausages, cured meats, minced meat) can trigger reactions. Poultry and fish are not affected, since alpha-gal is specific to mammals. Dairy is a gray area — some people with AGS react to dairy fat, but many don't; this isn't tagged in the tool, but worth asking about individually." }
+        ]
+      },
+      {
+        heading: "Diagnosis",
+        blocks: [
+          { type: "p", text: "A specific alpha-gal IgE blood test can confirm the diagnosis. Given the delayed and inconsistent symptom pattern, AGS is worth considering in unexplained nighttime allergic reactions or GI symptoms, especially in people with a known tick bite history." }
         ]
       }
     ]

--- a/articles.html
+++ b/articles.html
@@ -69,7 +69,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.4 — updated 16 July 2026</p>
+    <p>Pre-beta v0.5 — updated 16 July 2026</p>
 </footer>
 
 <script src="articles-data.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -55,7 +55,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.4 — updated 16 July 2026</p>
+        <p>Pre-beta v0.5 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.4 — updated 16 July 2026</p>
+        <p>Pre-beta v0.5 — updated 16 July 2026</p>
     </footer>
 
     <script src="foods-data.js"></script>


### PR DESCRIPTION
## Summary
- Reordered the `ARTICLES` object in `articles-data.js` so the article menu (articles.html) follows the same sequence as the filter list (`FILTER_SECTIONS` in foods-data.js): GI Irritants → FODMAPs (broad + subtypes: fructose, polyols, fructans, galactans, lactose) → Other Digestive Factors (fiber, histamine, bile stimulants) → Allergens → Cross-Reactivity & Delayed Allergy (+ alpha-gal).
- The macronutrient overview and the fat/protein/carbs articles (not filterable, so absent from the filter list) are kept together at the top as an intro group.
- Content of every article is untouched — verified programmatically that only the key order changed.
- Bumped version to v0.5.

## Test plan
- [x] Verified all 17 article keys are still present with identical body content
- [ ] Visual check of the articles.html sidebar menu order


---
_Generated by [Claude Code](https://claude.ai/code/session_011RFTNpYCoGNczVyDjYX34K)_