### PR TITLE
Add minimalist teaser popup to landing page demo

### DIFF
--- a/about.html
+++ b/about.html
@@ -110,7 +110,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.6 — updated 16 July 2026</p>
+        <p>Pre-beta v0.7 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/app.html
+++ b/app.html
@@ -157,7 +157,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.6 — updated 16 July 2026</p>
+    <p>Pre-beta v0.7 — updated 16 July 2026</p>
 </footer>
 
 <script src="foods-data.js"></script>

--- a/articles.html
+++ b/articles.html
@@ -69,7 +69,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.6 — updated 16 July 2026</p>
+    <p>Pre-beta v0.7 — updated 16 July 2026</p>
 </footer>
 
 <script src="articles-data.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -55,7 +55,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.6 — updated 16 July 2026</p>
+        <p>Pre-beta v0.7 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/index.html
+++ b/index.html
@@ -64,6 +64,15 @@
 
         <p class="demoDisclaimer">This mini-demo is for illustration only, not medical advice.
             <a href="app.html">Read the full disclaimer</a> in the app.</p>
+
+        <div class="demoPopupOverlay" id="demoPopupOverlay">
+            <div class="demoPopupBox" role="dialog" aria-modal="true" aria-labelledby="demoPopupTitle">
+                <button class="demoPopupClose" id="demoPopupClose" aria-label="Close">&times;</button>
+                <h3 id="demoPopupTitle"></h3>
+                <p id="demoPopupText"></p>
+                <a class="demoPopupLink" href="app.html">See the full analysis in the app →</a>
+            </div>
+        </div>
     </section>
 
     <section class="linksOut">
@@ -86,7 +95,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.6 — updated 16 July 2026</p>
+        <p>Pre-beta v0.7 — updated 16 July 2026</p>
     </footer>
 
     <script src="foods-data.js"></script>

--- a/landing.js
+++ b/landing.js
@@ -8,6 +8,32 @@ document.addEventListener("DOMContentLoaded", function () {
   const demoFoodsContainer = document.getElementById("demoFoods");
   const demoResultText = document.getElementById("demoResultText");
   const demoTraitList = document.getElementById("demoTraitList");
+  const demoPopupOverlay = document.getElementById("demoPopupOverlay");
+  const demoPopupTitle = document.getElementById("demoPopupTitle");
+  const demoPopupText = document.getElementById("demoPopupText");
+  const demoPopupClose = document.getElementById("demoPopupClose");
+
+  // Small teaser popup — one sentence pulled from the same TRAITS data the
+  // full app's analysis popup uses, just enough to show what's there.
+  function openDemoPopup(traitId) {
+    const trait = TRAITS[traitId];
+    if (!trait) return;
+    demoPopupTitle.textContent = trait.label;
+    demoPopupText.textContent = trait.analysis[0];
+    demoPopupOverlay.classList.add("show");
+  }
+
+  function closeDemoPopup() {
+    demoPopupOverlay.classList.remove("show");
+  }
+
+  demoPopupClose.addEventListener("click", closeDemoPopup);
+  demoPopupOverlay.addEventListener("click", function (e) {
+    if (e.target === demoPopupOverlay) closeDemoPopup();
+  });
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") closeDemoPopup();
+  });
 
   function findFoodTraits(name) {
     for (const category of CATEGORIES) {
@@ -69,6 +95,14 @@ document.addEventListener("DOMContentLoaded", function () {
       const li = document.createElement("li");
       const label = TRAITS[t.traitId] ? TRAITS[t.traitId].label : t.traitId;
       li.textContent = t.percent + "% — " + label;
+      if (TRAITS[t.traitId]) {
+        li.tabIndex = 0;
+        li.setAttribute("role", "button");
+        li.addEventListener("click", function () { openDemoPopup(t.traitId); });
+        li.addEventListener("keydown", function (e) {
+          if (e.key === "Enter" || e.key === " ") { e.preventDefault(); openDemoPopup(t.traitId); }
+        });
+      }
       demoTraitList.appendChild(li);
     });
   }

--- a/styles.css
+++ b/styles.css
@@ -1026,6 +1026,14 @@ footer p { color: var(--linen); }
     font-size: 17px;
     font-weight: 600;
     padding: 3px 0;
+    cursor: pointer;
+    text-decoration: underline dotted;
+    text-underline-offset: 3px;
+}
+
+.demoTraitList li:hover,
+.demoTraitList li:focus-visible {
+    color: var(--clay-dark);
 }
 
 .demoDisclaimer {
@@ -1033,6 +1041,71 @@ footer p { color: var(--linen); }
     opacity: 0.75;
     font-style: italic;
     text-align: center;
+}
+
+/* Mini "hint of the full app" popup, opened by tapping a shared trait */
+.demoPopupOverlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(12, 42, 49, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    z-index: 970;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+
+.demoPopupOverlay.show {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.demoPopupBox {
+    position: relative;
+    background: var(--paper);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    max-width: 360px;
+    width: 100%;
+    padding: 26px 22px 22px;
+    text-align: center;
+    box-shadow: 0 20px 50px rgba(21, 65, 76, 0.25);
+}
+
+.demoPopupBox h3 {
+    margin: 0 0 10px;
+    font-size: 21px;
+}
+
+.demoPopupBox p {
+    text-align: left;
+    font-size: 17px;
+    margin: 0 0 16px;
+}
+
+.demoPopupClose {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-size: 22px;
+    line-height: 1;
+    color: var(--primary);
+    cursor: pointer;
+}
+
+.demoPopupLink {
+    color: var(--clay-dark);
+    font-weight: bold;
+    text-decoration: none;
+}
+
+.demoPopupLink:hover {
+    text-decoration: underline;
 }
 
 .linksOut {


### PR DESCRIPTION
## Summary
- Tapping a shared trait in the landing-page mini-demo now opens a small, centered popup card (title + one line pulled from the trait's existing `analysis` text in foods-data.js, plus a link into the app).
- Kept deliberately minimal — a hint of the full app's analysis popup, not a copy of it.
- Bumped version to v0.7.

## Test plan
- [x] Verified in a headless mobile-viewport browser: clicking a trait shows the popup with correct title/text, close button and Escape both dismiss it


---
_Generated by [Claude Code](https://claude.ai/code/session_011RFTNpYCoGNczVyDjYX34K)_