### PR TITLE
Add demo hint text and collapsible mobile article menu

### DIFF
--- a/about.html
+++ b/about.html
@@ -110,7 +110,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.7 — updated 16 July 2026</p>
+        <p>Pre-beta v0.8 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/app.html
+++ b/app.html
@@ -157,7 +157,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.7 — updated 16 July 2026</p>
+    <p>Pre-beta v0.8 — updated 16 July 2026</p>
 </footer>
 
 <script src="foods-data.js"></script>

--- a/articles.html
+++ b/articles.html
@@ -69,7 +69,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.7 — updated 16 July 2026</p>
+    <p>Pre-beta v0.8 — updated 16 July 2026</p>
 </footer>
 
 <script src="articles-data.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -55,7 +55,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.7 — updated 16 July 2026</p>
+        <p>Pre-beta v0.8 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
         <div id="demoResult" class="demoResult">
             <p id="demoResultText">Select at least two foods to see what they share.</p>
             <ul id="demoTraitList" class="demoTraitList"></ul>
+            <p class="demoHint" id="demoHint" hidden>Click a trait to read more</p>
         </div>
 
         <p class="demoDisclaimer">This mini-demo is for illustration only, not medical advice.
@@ -95,7 +96,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.7 — updated 16 July 2026</p>
+        <p>Pre-beta v0.8 — updated 16 July 2026</p>
     </footer>
 
     <script src="foods-data.js"></script>

--- a/landing.js
+++ b/landing.js
@@ -8,6 +8,7 @@ document.addEventListener("DOMContentLoaded", function () {
   const demoFoodsContainer = document.getElementById("demoFoods");
   const demoResultText = document.getElementById("demoResultText");
   const demoTraitList = document.getElementById("demoTraitList");
+  const demoHint = document.getElementById("demoHint");
   const demoPopupOverlay = document.getElementById("demoPopupOverlay");
   const demoPopupTitle = document.getElementById("demoPopupTitle");
   const demoPopupText = document.getElementById("demoPopupText");
@@ -77,6 +78,7 @@ document.addEventListener("DOMContentLoaded", function () {
   function recomputeDemo() {
     const checked = Array.from(demoFoodsContainer.querySelectorAll("input:checked")).map(function (cb) { return cb.value; });
     demoTraitList.innerHTML = "";
+    demoHint.hidden = true;
 
     if (checked.length < 2) {
       demoResultText.textContent = "Select at least two foods to see what they share.";
@@ -89,6 +91,8 @@ document.addEventListener("DOMContentLoaded", function () {
       demoResultText.textContent = "These foods don't share a tracked trait — try a different combination.";
       return;
     }
+
+    demoHint.hidden = false;
 
     demoResultText.textContent = "Top shared traits among these " + checked.length + " foods:";
     topTraits.forEach(function (t) {

--- a/nav.js
+++ b/nav.js
@@ -77,4 +77,37 @@ document.addEventListener("DOMContentLoaded", function () {
       ticking = true;
     }
   }, { passive: true });
+
+  // ---- Collapsible article menu (mobile only — see the .collapsed rules
+  // scoped inside the mobile media query in styles.css) --------------------
+  document.querySelectorAll(".articleIndex").forEach(function (articleNav) {
+    const heading = articleNav.querySelector("h2");
+    const list = articleNav.querySelector("ul");
+    if (!heading || !list) return;
+
+    articleNav.classList.add("collapsed");
+    heading.setAttribute("role", "button");
+    heading.setAttribute("tabindex", "0");
+    heading.setAttribute("aria-expanded", "false");
+
+    function toggle() {
+      const collapsed = articleNav.classList.toggle("collapsed");
+      heading.setAttribute("aria-expanded", collapsed ? "false" : "true");
+    }
+
+    heading.addEventListener("click", toggle);
+    heading.addEventListener("keydown", function (e) {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        toggle();
+      }
+    });
+
+    list.addEventListener("click", function (e) {
+      if (e.target.tagName === "A") {
+        articleNav.classList.add("collapsed");
+        heading.setAttribute("aria-expanded", "false");
+      }
+    });
+  });
 });

--- a/styles.css
+++ b/styles.css
@@ -927,6 +927,22 @@ footer p { color: var(--linen); }
     .articleLayout { flex-direction: column; margin: 6vw; box-sizing: border-box; }
     .articleIndex { position: static; flex: none; width: 100%; box-sizing: border-box; }
 
+    /* Collapsible article menu — nav.js starts it collapsed and toggles
+       the class on tap; the heading gets a rotating chevron. */
+    .articleIndex h2 {
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+    .articleIndex h2::after {
+        content: "\25B8";
+        font-size: 16px;
+        transition: transform 0.2s ease;
+    }
+    .articleIndex:not(.collapsed) h2::after { transform: rotate(90deg); }
+    .articleIndex.collapsed ul { display: none; }
+
     /* Article/about body text: fixed-minimum size so it doesn't shrink
        below ~16px on narrow phones like the old pure-vw sizing did. */
     .articleContent p, .neck p, .articleContent li, .articleNote { font-size: clamp(18px, 4.5vw, 19px); }
@@ -1034,6 +1050,13 @@ footer p { color: var(--linen); }
 .demoTraitList li:hover,
 .demoTraitList li:focus-visible {
     color: var(--clay-dark);
+}
+
+.demoHint {
+    margin: 6px 0 0;
+    font-size: 14px;
+    font-style: italic;
+    opacity: 0.7;
 }
 
 .demoDisclaimer {


### PR DESCRIPTION
## Summary
- Landing page demo: a "Click a trait to read more" hint now appears under the shared-trait list once results are shown, so the popup interaction added earlier is more discoverable.
- Article menu (`.articleIndex`, shared by articles.html and about.html): now collapsible on mobile, starts collapsed, and auto-collapses again after a topic link is tapped. Desktop layout is unaffected.

## Test plan
- [x] Verified in a headless mobile-viewport browser: hint shows/hides correctly with selection count, article menu starts collapsed, toggles on heading click/tap, and re-collapses after a link click, on both articles.html and about.html
- [x] Verified desktop viewport still shows the article menu list regardless of the collapsed state class


---
_Generated by [Claude Code](https://claude.ai/code/session_011RFTNpYCoGNczVyDjYX34K)_