### PR TITLE
Fix chosen-foods spacing, disclaimer bar gap, and add no-save warning

### DIFF
--- a/about.html
+++ b/about.html
@@ -110,7 +110,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.8 — updated 16 July 2026</p>
+        <p>Pre-beta v0.9 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/app.html
+++ b/app.html
@@ -94,9 +94,10 @@
                     <span class="stepDetail">Open the popup for a deeper breakdown of likely culprits.</span>
                 </li>
             </ol>
+            <p class="noSaveWarning"><strong>Nothing here is saved.</strong> The only way to keep a record is to open the analysis and choose to print it or save it as a PDF.</p>
         </div>
         <div id="chosenFoods">
-            <h2>Chosen items:</h2>
+            <h2>Chosen foods:</h2>
             <div id="chosenText">Click on a category to show lists of foods</div>
         </div>
         <div class="searchContainer" id="searchContainer">
@@ -157,7 +158,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.8 — updated 16 July 2026</p>
+    <p>Pre-beta v0.9 — updated 16 July 2026</p>
 </footer>
 
 <script src="foods-data.js"></script>

--- a/articles.html
+++ b/articles.html
@@ -69,7 +69,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.8 — updated 16 July 2026</p>
+    <p>Pre-beta v0.9 — updated 16 July 2026</p>
 </footer>
 
 <script src="articles-data.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -55,7 +55,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.8 — updated 16 July 2026</p>
+        <p>Pre-beta v0.9 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.8 — updated 16 July 2026</p>
+        <p>Pre-beta v0.9 — updated 16 July 2026</p>
     </footer>
 
     <script src="foods-data.js"></script>

--- a/nav.js
+++ b/nav.js
@@ -43,8 +43,11 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   // Header is fixed, so reserve the equivalent space at the top of the page.
+  // The --header-height variable lets .disclaimerBar (see styles.css) extend
+  // its own background up behind the header instead of leaving a gap.
   function syncHeaderHeight() {
     document.body.style.paddingTop = header.offsetHeight + "px";
+    document.documentElement.style.setProperty("--header-height", header.offsetHeight + "px");
   }
   syncHeaderHeight();
   window.addEventListener("resize", syncHeaderHeight);

--- a/styles.css
+++ b/styles.css
@@ -204,16 +204,20 @@ header.header--hidden {
     color: var(--primary);
 }
 
-/* Disclaimer bar */
+/* Disclaimer bar — extended up behind the fixed header (via negative
+   margin + matching extra padding) so hiding the header on scroll reveals
+   this bar's own background instead of a lighter gap. */
 .disclaimerBar {
     background: var(--linen);
     border-bottom: 1px solid var(--border);
-    padding: 10px 16px;
+    margin-top: calc(-1 * var(--header-height, 84px));
+    padding: calc(var(--header-height, 84px) + 10px) 16px 10px;
     display: flex;
     justify-content: center;
     align-items: center;
     gap: 14px;
     flex-wrap: wrap;
+    position: relative;
 }
 
 .disclaimerCheck {
@@ -352,10 +356,22 @@ header.header--hidden {
     margin-right: 5px;
 }
 
+.noSaveWarning {
+    margin: 16px 0 0;
+    padding: 10px 14px;
+    background: rgba(201, 138, 94, 0.15);
+    border: 1px solid var(--clay);
+    border-radius: 8px;
+    font-size: 15px;
+    color: var(--clay-dark);
+    text-align: center;
+}
+
 #chosenFoods {
     border-top: 1px solid var(--border);
     margin-top: 22px;
     padding-top: 18px;
+    padding-bottom: 18px;
 }
 
 #chosenText {


### PR DESCRIPTION
## Summary
- "Chosen items:" → "Chosen foods:"
- `#chosenFoods` now has padding-bottom so selected food chips don't sit flush against the search bar below on mobile.
- `.disclaimerBar` now extends its background up behind the fixed header (via a `--header-height` CSS var kept in sync by nav.js), so hiding the header on scroll no longer reveals a lighter gap at the top of the screen.
- Added a "Nothing here is saved" warning right after the instructions box, since printing/saving the analysis popup is the only way to keep a record.
- Bumped version to v0.9.

## Test plan
- [x] Verified in a headless mobile-viewport browser: 18px gap now exists between the last chosen-food chip and the search bar
- [x] Verified the disclaimer bar's background now reaches the very top of the viewport once the header auto-hides on a small scroll (previously showed a lighter gap)
- [x] Verified the warning text renders directly under the numbered instructions


---
_Generated by [Claude Code](https://claude.ai/code/session_011RFTNpYCoGNczVyDjYX34K)_