### PR TITLE
Add "Clear selection" box with confirm-guarded Foods/Filter/All buttons

### DIFF
--- a/about.html
+++ b/about.html
@@ -110,7 +110,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.9 — updated 16 July 2026</p>
+        <p>Pre-beta v0.10 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/app.html
+++ b/app.html
@@ -140,10 +140,17 @@
         <div id="printArticlesList" class="printOnly"></div>
 
         <button class="button2 noPrint" id="showAnalysisButton" name="Show Analysis Popup">Show Analysis</button>
-        <button class="button2 noPrint" id="restartButton" name="Restart">Restart</button>
+
+        <div class="clearSelectionBox noPrint" id="clearSelectionBox">
+            <h2>Clear selection</h2>
+            <div class="clearButtonRow">
+                <button class="button2" id="clearFoodsButton" type="button">Foods</button>
+                <button class="button2" id="clearFiltersButton" type="button">Filter</button>
+                <button class="button2" id="restartButton" type="button">All</button>
+            </div>
+        </div>
 
         <h2 class="noPrint">Filter Analysis</h2>
-        <button class="button2 noPrint" id="clearFiltersButton" name="Clear Filters">Clear Filters</button>
         <p class="noPrint">Select one or more factors to exclude from the analysis. Filters update the analysis immediately, even
             after foods are already selected.</p>
 
@@ -158,7 +165,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.9 — updated 16 July 2026</p>
+    <p>Pre-beta v0.10 — updated 16 July 2026</p>
 </footer>
 
 <script src="foods-data.js"></script>

--- a/articles.html
+++ b/articles.html
@@ -69,7 +69,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.9 — updated 16 July 2026</p>
+    <p>Pre-beta v0.10 — updated 16 July 2026</p>
 </footer>
 
 <script src="articles-data.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -55,7 +55,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.9 — updated 16 July 2026</p>
+        <p>Pre-beta v0.10 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.9 — updated 16 July 2026</p>
+        <p>Pre-beta v0.10 — updated 16 July 2026</p>
     </footer>
 
     <script src="foods-data.js"></script>

--- a/script.js
+++ b/script.js
@@ -640,19 +640,28 @@
     showAllCategories();
   });
 
-  // ---- Restart ------------------------------------------------------------
+  // ---- Clear selection (Foods / Filter / All) -----------------------------
+  document.getElementById("clearFoodsButton").addEventListener("click", function () {
+    if (!window.confirm("Clear all selected foods?")) return;
+    topSection.querySelectorAll("input[type='checkbox']").forEach(function (cb) { cb.checked = false; });
+    recompute();
+  });
+
+  document.getElementById("clearFiltersButton").addEventListener("click", function () {
+    if (!window.confirm("Clear all filters?")) return;
+    filterContainer.querySelectorAll("input[type='checkbox']").forEach(function (cb) { cb.checked = false; });
+    recompute();
+  });
+
   restartButton.addEventListener("click", function () {
+    if (!window.confirm("Clear everything — foods, filters, and search?")) return;
     topSection.querySelectorAll("input[type='checkbox']").forEach(function (cb) { cb.checked = false; });
     filterContainer.querySelectorAll("input[type='checkbox']").forEach(function (cb) { cb.checked = false; });
     topSection.querySelectorAll("label").forEach(function (label) { label.style.display = ""; });
     searchField.value = "";
     hideAllCategories();
     recompute();
-  });
-
-  document.getElementById("clearFiltersButton").addEventListener("click", function () {
-    filterContainer.querySelectorAll("input[type='checkbox']").forEach(function (cb) { cb.checked = false; });
-    recompute();
+    document.getElementById("chosenFoods").scrollIntoView({ behavior: "smooth", block: "start" });
   });
 
   // ---- Boot ----------------------------------------------------------------

--- a/styles.css
+++ b/styles.css
@@ -313,6 +313,32 @@ header.header--hidden {
     margin-top: 0;
 }
 
+.clearSelectionBox {
+    max-width: 640px;
+    margin: 24px auto;
+    padding: 18px 26px;
+    background: var(--paper);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    text-align: center;
+}
+
+.clearSelectionBox h2 {
+    margin-top: 0;
+    margin-bottom: 4px;
+}
+
+.clearButtonRow {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.clearButtonRow .button2 {
+    margin: 5px;
+}
+
 .stepsList {
     list-style: none;
     counter-reset: step;


### PR DESCRIPTION
## Summary
- New "Clear selection" box sits between the Show Analysis button and the Filter Analysis heading, with three buttons:
  - **Foods** (new) — clears only selected foods
  - **Filter** (was "Clear Filters") — clears only filters, moved into the box
  - **All** (was "Restart") — clears everything, moved into the box
- Each button now shows a native confirm dialog before clearing anything, so an accidental tap can't wipe a selection.
- Clicking "All" also scrolls back up to the "Chosen foods" section afterward.
- Bumped version to v0.10.

## Test plan
- [x] Verified in a headless mobile-viewport browser: cancelling a confirm dialog leaves the selection untouched; confirming each button clears only its own scope (Foods/Filter/All); "All" scrolls back to #chosenFoods


---
_Generated by [Claude Code](https://claude.ai/code/session_011RFTNpYCoGNczVyDjYX34K)_