### PR TITLE
Tighten About page: merge Background/Why content, reword bile stimulant note

### DIFF
--- a/about.html
+++ b/about.html
@@ -58,16 +58,15 @@
                     seemingly unrelated foods, and the shared thread — a FODMAP subtype, a histamine load, a
                     cross-reactive allergen — only becomes visible once someone lays every food's traits side by
                     side.</p>
-                <p>Doing that by hand, meal by meal, is slow and easy to get wrong. This tool automates the
-                    side-by-side comparison so the pattern shows up in seconds instead of a week of food diaries.</p>
             </section>
 
             <section id="why">
                 <h2>Why this tool exists</h2>
-                <p>Food intolerance and sensitivity work is full of diagnoses that get missed simply because
-                    nobody thought to check for them — alpha-gal syndrome, oral allergy syndrome, secondary
-                    lactose intolerance from undiagnosed coeliac disease. This tool is meant to surface exactly
-                    those overlooked possibilities, not replace a proper clinical workup.</p>
+                <p>Food intolerance work is full of diagnoses missed simply because nobody thought to check —
+                    alpha-gal syndrome, oral allergy syndrome, secondary lactose intolerance from undiagnosed
+                    coeliac disease. Spotting the shared thread by hand, meal by meal, is slow and easy to get
+                    wrong; this tool automates that comparison in seconds, surfacing overlooked possibilities
+                    without replacing a proper clinical workup.</p>
             </section>
 
             <section id="methodology">
@@ -81,11 +80,12 @@
                     trait ranking, they only appear as a side note when they're extremely common across your
                     selection (over 90% of foods) — a signal that they may be worsening symptoms driven by
                     something else.</p>
-                <p>Some traits, like <strong>bile stimulant</strong>, are only assigned to foods that clearly
-                    cross a clinical threshold — currently over 17.5g fat or over 20g protein per 100g, based on
-                    EU food-labeling "high fat"/"high protein" categories. That's why you'll see foods like sour
-                    cream, ground meat, and Greek yogurt split into separate low-fat, medium-fat, and full-fat
-                    entries: the fat content genuinely changes whether the trait applies.</p>
+                <p>Some traits, like <strong>Bile Stimulant</strong>, are only assigned to foods that clearly
+                    cross certain thresholds — currently over 17.5g fat or over 20g protein per 100g (based on
+                    EU food-labeling "high fat"/"high protein" categories) for the trait Bile Stimulant. That's
+                    why you'll see foods like sour cream, ground meat, and Greek yogurt split into separate
+                    low-fat, medium-fat, and full-fat entries: the fat content genuinely changes whether the
+                    trait applies.</p>
             </section>
 
             <section id="sources">
@@ -110,7 +110,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.10 — updated 16 July 2026</p>
+        <p>Pre-beta v0.11 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/app.html
+++ b/app.html
@@ -165,7 +165,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.10 — updated 16 July 2026</p>
+    <p>Pre-beta v0.11 — updated 16 July 2026</p>
 </footer>
 
 <script src="foods-data.js"></script>

--- a/articles.html
+++ b/articles.html
@@ -69,7 +69,7 @@
     <p>Did you find any errors or have ideas for improvement?</p>
     <p>Email: Monsterardadrys@duck.com</p>
     <p>Uppsala, Sweden, 2026</p>
-    <p>Pre-beta v0.10 — updated 16 July 2026</p>
+    <p>Pre-beta v0.11 — updated 16 July 2026</p>
 </footer>
 
 <script src="articles-data.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -55,7 +55,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.10 — updated 16 July 2026</p>
+        <p>Pre-beta v0.11 — updated 16 July 2026</p>
     </footer>
 
     <script src="nav.js"></script>

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
 
     <footer>
         <p>Built by a dietitian, for dietitians (and the curious).</p>
-        <p>Pre-beta v0.10 — updated 16 July 2026</p>
+        <p>Pre-beta v0.11 — updated 16 July 2026</p>
     </footer>
 
     <script src="foods-data.js"></script>


### PR DESCRIPTION
## Summary
- Moved the "doing this by hand is slow" point from Background into Why this tool exists (where it fits better) and tightened the wording so that section doesn't grow longer than before.
- Reworded the Bile Stimulant threshold sentence per updated content.
- Bumped version to v0.11.


---
_Generated by [Claude Code](https://claude.ai/code/session_011RFTNpYCoGNczVyDjYX34K)_